### PR TITLE
Initial scheduler

### DIFF
--- a/CpvMacros.h
+++ b/CpvMacros.h
@@ -1,47 +1,28 @@
+#ifndef CPV_MACROS_H
+#define CPV_MACROS_H
+
+#include "convcore.h"
+
 #define CMK_TAG(x, y) x##y##_
-#define CpvAccess(v) CMK_TAG(Cpv_, v)[_Cmi_myrank]
-#define CpvDeclare(t, v) t CMK_TAG(Cpv_, v)[2]
-#define CpvStaticDeclare(t, v) static t CMK_TAG(Cpv_, v)[2]
 
-// define variables (do we use cpv or cth here?)
-CpvDeclare(CmiHandlerInfo *, CmiHandlerTable);
-CpvStaticDeclare(int, CmiHandlerCount);
-CpvStaticDeclare(int, CmiHandlerLocal);
-CpvStaticDeclare(int, CmiHandlerGlobal);
-CpvDeclare(int, CmiHandlerMax);
+#define CpvDeclare(t, v) t *CMK_TAG(Cpv_, v)
+#define CpvStaticDeclare(t, v) static t *CMK_TAG(Cpv_, v)
 
-// static void CmiExtendHandlerTable(int atLeastLen)
-// {
-//     int max = CpvAccess(CmiHandlerMax);
-//     int newmax = (atLeastLen + (atLeastLen >> 2) + 32);
-//     int bytes = max * sizeof(CmiHandlerInfo);
-//     int newbytes = newmax * sizeof(CmiHandlerInfo);
-//     CmiHandlerInfo *nu = (CmiHandlerInfo *)malloc(newbytes);
-//     CmiHandlerInfo *tab = CpvAccess(CmiHandlerTable);
-//     _MEMCHECK(nu);
-//     if (tab)
-//     {
-//         memcpy(nu, tab, bytes);
-//     }
-//     memset(((char *)nu) + bytes, 0, (newbytes - bytes));
-//     free(tab);
-//     tab = nu;
-//     CpvAccess(CmiHandlerTable) = tab;
-//     CpvAccess(CmiHandlerMax) = newmax;
-// }
-// void CmiNumberHandler(int n, CmiHandler h)
-// {
-//     CmiHandlerInfo *tab;
-//     if (n >= CpvAccess(CmiHandlerMax))
-//         CmiExtendHandlerTable(n);
-//     tab = CpvAccess(CmiHandlerTable);
-//     tab[n].hdlr = (CmiHandlerEx)h; /* LIE!  This assumes extra pointer will be ignored!*/
-//     tab[n].userPtr = 0;
-// }
-// int CmiRegisterHandler(CmiHandler h)
-// {
-//     int Count = CpvAccess(CmiHandlerCount);
-//     CmiNumberHandler(Count, h);
-//     CpvAccess(CmiHandlerCount) = Count + DIST_BETWEEN_HANDLERS;
-//     return Count;
-// }
+#define CpvInitialize(t, v)                            \
+    do                                                 \
+    {                                                  \
+        if (CmiMyPE())                                 \
+        {                                              \
+            CmiNodeBarrier();                          \
+        }                                              \
+        else                                           \
+        {                                              \
+            CMK_TAG(Cpv_, v) = new t[CmiMyNodeSize()]; \
+            CmiNodeBarrier();                          \
+        }                                              \
+    } while (0)
+;
+
+#define CpvAccess(v) CMK_TAG(Cpv_, v)[CmiMyPE()]
+
+#endif

--- a/CpvMacros.h
+++ b/CpvMacros.h
@@ -9,38 +9,39 @@ CpvStaticDeclare(int, CmiHandlerCount);
 CpvStaticDeclare(int, CmiHandlerLocal);
 CpvStaticDeclare(int, CmiHandlerGlobal);
 CpvDeclare(int, CmiHandlerMax);
-static void CmiExtendHandlerTable(int atLeastLen)
-{
-    int max = CpvAccess(CmiHandlerMax);
-    int newmax = (atLeastLen + (atLeastLen >> 2) + 32);
-    int bytes = max * sizeof(CmiHandlerInfo);
-    int newbytes = newmax * sizeof(CmiHandlerInfo);
-    CmiHandlerInfo *nu = (CmiHandlerInfo *)malloc(newbytes);
-    CmiHandlerInfo *tab = CpvAccess(CmiHandlerTable);
-    _MEMCHECK(nu);
-    if (tab)
-    {
-        memcpy(nu, tab, bytes);
-    }
-    memset(((char *)nu) + bytes, 0, (newbytes - bytes));
-    free(tab);
-    tab = nu;
-    CpvAccess(CmiHandlerTable) = tab;
-    CpvAccess(CmiHandlerMax) = newmax;
-}
-void CmiNumberHandler(int n, CmiHandler h)
-{
-    CmiHandlerInfo *tab;
-    if (n >= CpvAccess(CmiHandlerMax))
-        CmiExtendHandlerTable(n);
-    tab = CpvAccess(CmiHandlerTable);
-    tab[n].hdlr = (CmiHandlerEx)h; /* LIE!  This assumes extra pointer will be ignored!*/
-    tab[n].userPtr = 0;
-}
-int CmiRegisterHandler(CmiHandler h)
-{
-    int Count = CpvAccess(CmiHandlerCount);
-    CmiNumberHandler(Count, h);
-    CpvAccess(CmiHandlerCount) = Count + DIST_BETWEEN_HANDLERS;
-    return Count;
-}
+
+// static void CmiExtendHandlerTable(int atLeastLen)
+// {
+//     int max = CpvAccess(CmiHandlerMax);
+//     int newmax = (atLeastLen + (atLeastLen >> 2) + 32);
+//     int bytes = max * sizeof(CmiHandlerInfo);
+//     int newbytes = newmax * sizeof(CmiHandlerInfo);
+//     CmiHandlerInfo *nu = (CmiHandlerInfo *)malloc(newbytes);
+//     CmiHandlerInfo *tab = CpvAccess(CmiHandlerTable);
+//     _MEMCHECK(nu);
+//     if (tab)
+//     {
+//         memcpy(nu, tab, bytes);
+//     }
+//     memset(((char *)nu) + bytes, 0, (newbytes - bytes));
+//     free(tab);
+//     tab = nu;
+//     CpvAccess(CmiHandlerTable) = tab;
+//     CpvAccess(CmiHandlerMax) = newmax;
+// }
+// void CmiNumberHandler(int n, CmiHandler h)
+// {
+//     CmiHandlerInfo *tab;
+//     if (n >= CpvAccess(CmiHandlerMax))
+//         CmiExtendHandlerTable(n);
+//     tab = CpvAccess(CmiHandlerTable);
+//     tab[n].hdlr = (CmiHandlerEx)h; /* LIE!  This assumes extra pointer will be ignored!*/
+//     tab[n].userPtr = 0;
+// }
+// int CmiRegisterHandler(CmiHandler h)
+// {
+//     int Count = CpvAccess(CmiHandlerCount);
+//     CmiNumberHandler(Count, h);
+//     CpvAccess(CmiHandlerCount) = Count + DIST_BETWEEN_HANDLERS;
+//     return Count;
+// }

--- a/CpvMacros.h
+++ b/CpvMacros.h
@@ -3,6 +3,9 @@
 
 #include "convcore.h"
 
+// NOTE: these are solely for backwards compatibility
+// Do not use in reconverse impl
+
 #define CMK_TAG(x, y) x##y##_
 
 #define CpvDeclare(t, v) t *CMK_TAG(Cpv_, v)

--- a/CpvMacros.h
+++ b/CpvMacros.h
@@ -1,0 +1,46 @@
+#define CMK_TAG(x, y) x##y##_
+#define CpvAccess(v) CMK_TAG(Cpv_, v)[_Cmi_myrank]
+#define CpvDeclare(t, v) t CMK_TAG(Cpv_, v)[2]
+#define CpvStaticDeclare(t, v) static t CMK_TAG(Cpv_, v)[2]
+
+// define variables (do we use cpv or cth here?)
+CpvDeclare(CmiHandlerInfo *, CmiHandlerTable);
+CpvStaticDeclare(int, CmiHandlerCount);
+CpvStaticDeclare(int, CmiHandlerLocal);
+CpvStaticDeclare(int, CmiHandlerGlobal);
+CpvDeclare(int, CmiHandlerMax);
+static void CmiExtendHandlerTable(int atLeastLen)
+{
+    int max = CpvAccess(CmiHandlerMax);
+    int newmax = (atLeastLen + (atLeastLen >> 2) + 32);
+    int bytes = max * sizeof(CmiHandlerInfo);
+    int newbytes = newmax * sizeof(CmiHandlerInfo);
+    CmiHandlerInfo *nu = (CmiHandlerInfo *)malloc(newbytes);
+    CmiHandlerInfo *tab = CpvAccess(CmiHandlerTable);
+    _MEMCHECK(nu);
+    if (tab)
+    {
+        memcpy(nu, tab, bytes);
+    }
+    memset(((char *)nu) + bytes, 0, (newbytes - bytes));
+    free(tab);
+    tab = nu;
+    CpvAccess(CmiHandlerTable) = tab;
+    CpvAccess(CmiHandlerMax) = newmax;
+}
+void CmiNumberHandler(int n, CmiHandler h)
+{
+    CmiHandlerInfo *tab;
+    if (n >= CpvAccess(CmiHandlerMax))
+        CmiExtendHandlerTable(n);
+    tab = CpvAccess(CmiHandlerTable);
+    tab[n].hdlr = (CmiHandlerEx)h; /* LIE!  This assumes extra pointer will be ignored!*/
+    tab[n].userPtr = 0;
+}
+int CmiRegisterHandler(CmiHandler h)
+{
+    int Count = CpvAccess(CmiHandlerCount);
+    CmiNumberHandler(Count, h);
+    CpvAccess(CmiHandlerCount) = Count + DIST_BETWEEN_HANDLERS;
+    return Count;
+}

--- a/barrier.h
+++ b/barrier.h
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+
+class Barrier
+{
+private:
+    std::mutex mtx;
+    std::condition_variable cv;
+    int count;
+    int thread_count;
+
+public:
+    explicit Barrier(int num_threads) : count(0), thread_count(num_threads) {}
+
+    void wait()
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        count++;
+
+        if (count == thread_count)
+        {              // Last thread to arrive
+            count = 0; // Reset barrier for potential reuse
+            cv.notify_all();
+        }
+        else
+        {
+            cv.wait(lock, [this]
+                    { return count == 0; });
+        }
+    }
+};

--- a/barrier.h
+++ b/barrier.h
@@ -11,25 +11,28 @@ private:
     std::condition_variable cv;
     int count;
     int thread_count;
+    int iteration;
 
 public:
-    explicit Barrier(int num_threads) : count(0), thread_count(num_threads) {}
+    explicit Barrier(int num_threads) : count(0), thread_count(num_threads), iteration(0) {}
 
     void wait()
     {
         std::unique_lock<std::mutex> lock(mtx);
+        int threadlocal_iteration = iteration;
         count++;
 
         if (count == thread_count)
         {
             count = 0; // Reset barrier for potential reuse
+            iteration++;
             cv.notify_all();
             lock.unlock();
         }
         else
         {
-            cv.wait(lock, [this]
-                    { return count == 0; });
+            cv.wait(lock, [this, threadlocal_iteration]
+                    { return iteration != threadlocal_iteration; });
         }
     }
 };

--- a/barrier.h
+++ b/barrier.h
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <condition_variable>
 
+// TODO: this is not reusable - on trying to reuse barrier it hangs
 class Barrier
 {
 private:
@@ -20,9 +21,10 @@ public:
         count++;
 
         if (count == thread_count)
-        {              // Last thread to arrive
+        {
             count = 0; // Reset barrier for potential reuse
             cv.notify_all();
+            lock.unlock();
         }
         else
         {

--- a/convcore.C
+++ b/convcore.C
@@ -14,7 +14,7 @@ void *converseRunPe(void *args)
     return NULL;
 }
 
-static void CmiStartThreads()
+void CmiStartThreads()
 {
     pthread_t threadId[Cmi_npes];
     for (int i = 0; i < Cmi_npes; i++)

--- a/convcore.C
+++ b/convcore.C
@@ -2,32 +2,41 @@
 #include "convcore.h"
 #include "scheduler.h"
 #include "CpvMacros.h"
+#include "barrier.h"
 
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
 
+// GLOBALS
 int Cmi_argc;
 static char **Cmi_argv;
 int Cmi_npes;
 
-// define variables (do we use cpv or cth here?)
-CpvDeclare(CmiHandlerInfo *, CmiHandlerTable);
-CpvStaticDeclare(int, CmiHandlerCount);
-CpvStaticDeclare(int, CmiHandlerLocal);
-CpvStaticDeclare(int, CmiHandlerGlobal);
-CpvDeclare(int, CmiHandlerMax);
+// PE LOCALS that need global access sometimes
+CmiState **Cmi_states; // array of state pointers
 
-thread_local CmiState *Cmi_state;
+// PE LOCALS
+thread_local int CmiHandlerCount = 0;
+thread_local int CmiHandlerMax = 10;
+thread_local std::vector<CmiHandlerInfo> CmiHandlerTable;
+thread_local int Cmi_pe; // store my state alone
+
+// TODO: padding for all these thread_locals and cmistates?
+
+void CmiCallHandler(int handler, void *msg)
+{
+    printf("Calling handler\n");
+    CmiHandlerTable[handler].hdlr(msg);
+}
 
 void *converseRunPe(void *args)
 {
+    printf("Running PE\n");
     // init state
     int pe = *(int *)args;
     CmiInitState(pe);
-
-    // declare handler structs
-    CpvDeclare(CmiHandlerInfo *, CmiHandlerTable);
 
     // call initial function and start scheduler
     Cmi_startfn(Cmi_argc, Cmi_argv);
@@ -43,6 +52,9 @@ void CmiStartThreads()
     // TODO: how to get enumerated pe nums for each thread?
     // this would be much cleaner with std::threads
     int threadPeNums[Cmi_npes];
+
+    // allocate state array
+    Cmi_states = (CmiState **)malloc(sizeof(CmiState *) * Cmi_npes);
 
     for (int i = 0; i < Cmi_npes; i++)
     {
@@ -77,22 +89,31 @@ void ConverseInit(int argc, char **argv, CmiStartFn fn)
 }
 
 // CMI STATE
-static pthread_key_t Cmi_state_key = (pthread_key_t)(-1);
 
 CmiState *
 CmiGetState(void)
 {
-    return Cmi_state;
+    return Cmi_states[Cmi_pe];
+};
+
+CmiState *
+CmiGetState(int pe)
+{
+    return Cmi_states[pe];
 };
 
 void CmiInitState(int pe)
 {
-    Cmi_state = new CmiState;
+
+    CmiState *Cmi_state = new CmiState;
     Cmi_state->pe = pe;  // TODO: for now, pe is just thread index
     Cmi_state->node = 0; // TODO: get node
 
     ConverseQueue<CmiMessage> queue;
     Cmi_state->queue = queue;
+
+    Cmi_states[pe] = Cmi_state;
+    Cmi_pe = pe;
 }
 
 int CmiMyPE()
@@ -112,7 +133,7 @@ int CmiMyNodeSize()
 
 void CmiPushPE(int destPE, int messageSize, void *msg)
 {
-    // TODO: add message to PE-level queue
+    CmiGetState(destPE)->queue.push(*(CmiMessage *)msg);
 }
 
 void CmiSyncSendAndFree(int destPE, int messageSize, void *msg)
@@ -128,50 +149,52 @@ void CmiSyncSendAndFree(int destPE, int messageSize, void *msg)
     }
 }
 
-// HANDLER TOOLS
-static void CmiExtendHandlerTable(int atLeastLen)
-{
-    int max = CpvAccess(CmiHandlerMax);
-    int newmax = (atLeastLen + (atLeastLen >> 2) + 32);
-    int bytes = max * sizeof(CmiHandlerInfo);
-    int newbytes = newmax * sizeof(CmiHandlerInfo);
-    CmiHandlerInfo *nu = (CmiHandlerInfo *)malloc(newbytes);
-    CmiHandlerInfo *tab = CpvAccess(CmiHandlerTable);
-    // _MEMCHECK(nu);
-    if (tab)
-    {
-        memcpy(nu, tab, bytes);
-    }
-    memset(((char *)nu) + bytes, 0, (newbytes - bytes));
-    free(tab);
-    tab = nu;
-    CpvAccess(CmiHandlerTable) = tab;
-    CpvAccess(CmiHandlerMax) = newmax;
-}
-void CmiNumberHandler(int n, CmiHandler h)
-{
-    CmiHandlerInfo *tab;
-    if (n >= CpvAccess(CmiHandlerMax))
-        CmiExtendHandlerTable(n);
-    tab = CpvAccess(CmiHandlerTable);
-    tab[n].hdlr = (CmiHandlerEx)h; /* LIE!  This assumes extra pointer will be ignored!*/
-    tab[n].userPtr = 0;
-}
+// // HANDLER TOOLS
+// static void CmiExtendHandlerTable(int atLeastLen)
+// {
+//     int max = CmiHandlerMax;
+//     int newmax = (atLeastLen + (atLeastLen >> 2) + 32);
+//     int bytes = max * sizeof(CmiHandlerInfo);
+//     int newbytes = newmax * sizeof(CmiHandlerInfo);
+//     CmiHandlerInfo *nu = (CmiHandlerInfo *)malloc(newbytes);
+//     CmiHandlerInfo *tab = CmiHandlerTable;
+//     // _MEMCHECK(nu);
+//     if (tab)
+//     {
+//         memcpy(nu, tab, bytes);
+//     }
+//     memset(((char *)nu) + bytes, 0, (newbytes - bytes));
+//     free(tab);
+//     tab = nu;
+//     CmiHandlerTable = tab;
+//     CmiHandlerMax = newmax;
+// }
+
+// void CmiNumberHandler(int n, CmiHandler h)
+// {
+
+//     CmiHandlerInfo *tab;
+//     if (n >= CmiHandlerMax)
+//         CmiExtendHandlerTable(n);
+//     tab = CmiHandlerTable;
+//     tab[n].hdlr = (CmiHandler)h; /* LIE!  This assumes extra pointer will be ignored!*/
+//     tab[n].userPtr = 0;
+
+//     CmiHandlerTable = tab;
+// }
 
 #define DIST_BETWEEN_HANDLERS 1
 int CmiRegisterHandler(CmiHandler h)
 {
-    int Count = CpvAccess(CmiHandlerCount);
-    CmiNumberHandler(Count, h);
-    CpvAccess(CmiHandlerCount) = Count + DIST_BETWEEN_HANDLERS;
-    return Count;
+
+    // add handler to vector
+
+    CmiHandlerTable.push_back({h, nullptr});
+    return CmiHandlerTable.size() - 1;
 }
 
-// NODE BARRIER
 void CmiNodeBarrier(void)
 {
-    // static Barrier nodeBarrier(CmiMyNodeSize());
-    // nodeBarrier.arrive_and_wait();
-
-    // TODO: implement barrier
+    static Barrier nodeBarrier(CmiMyNodeSize());
+    nodeBarrier.wait(); // TODO: this may be broken...
 }

--- a/convcore.C
+++ b/convcore.C
@@ -41,7 +41,6 @@ void *converseRunPe(void *args)
 
     // call initial function and start scheduler
     Cmi_startfn(Cmi_argc, Cmi_argv);
-    CmiNodeBarrier();
     CsdScheduler();
 
     return NULL;

--- a/convcore.C
+++ b/convcore.C
@@ -5,10 +5,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+int Cmi_npes;
+int Cmi_argc;
+
 void *converseRunPe(void *args)
 {
     // call cmi start function, pass args to it
     Cmi_startfn(Cmi_argc, Cmi_argv);
+
+    // init state struct
+    CmiInitState();
+
     // call scheduler
     CsdScheduler();
     return NULL;
@@ -55,13 +62,23 @@ CmiGetState(void)
     return state;
 };
 
+CmiState
+CmiGetState(int pe)
+{
+    // TODO get state of pe
+    CmiState state;
+    return state;
+}
+
 void CmiInitState()
 {
     CmiState state = CmiGetState();
     state.pe = 0; // TOOD: get pe from thread info
     state.rank = 0;
 
-    // TODO: store state in some global array indexed by thread id
+    state.queue = ConverseQueue<CmiMessage>();
+
+    // TODO: store state in some global array
 }
 
 int CmiMyPE()
@@ -76,7 +93,7 @@ int CmiMyNode()
 
 void CmiPushPE(int destPE, int messageSize, void *msg)
 {
-    // TODO: add message to node-level queue
+    // TODO: add message to PE-level queue
 }
 
 void CmiSyncSendAndFree(int destPE, int messageSize, void *msg)

--- a/convcore.C
+++ b/convcore.C
@@ -41,6 +41,7 @@ void *converseRunPe(void *args)
 
     // call initial function and start scheduler
     Cmi_startfn(Cmi_argc, Cmi_argv);
+    CmiNodeBarrier();
     CsdScheduler();
 
     return NULL;

--- a/convcore.h
+++ b/convcore.h
@@ -2,12 +2,11 @@
 #define CONVCORE_H
 
 #include "converse.h"
+#include "queue.h"
 
 static char **Cmi_argv;
 
 static CmiStartFn Cmi_startfn;
-int Cmi_npes;
-int Cmi_argc;
 
 void CmiStartThreads(char **argv);
 
@@ -24,7 +23,7 @@ typedef struct Header
 
 #define CmiMessageHeaderSize sizeof(CmiMessageHeader)
 
-typedef struct Message
+typedef struct CmiMessageStruct
 {
     CmiMessageHeader header;
     char data[];
@@ -34,10 +33,13 @@ typedef struct State
 {
     int pe;
     int rank;
+    ConverseQueue<CmiMessage> queue;
+
 } CmiState;
 
 // state relevant functionality
 CmiState CmiGetState(void);
+CmiState CmiGetState(int pe);
 void CmiInitState();
 
 // state getters

--- a/convcore.h
+++ b/convcore.h
@@ -4,8 +4,6 @@
 #include "converse.h"
 #include "queue.h"
 
-#include "CpvMacros.h"
-
 typedef void (*CmiStartFn)(int argc, char **argv);
 void ConverseInit(int argc, char **argv, CmiStartFn fn);
 
@@ -29,7 +27,7 @@ typedef struct CmiMessageStruct
 // TODO: what is CmiHandlerEx in old converse?
 
 typedef void (*CmiHandler)(void *msg);
-typedef void (*CmiHandlerEx)(void *msg, void *userPtr);
+typedef void (*CmiHandlerEx)(void *msg, void *userPtr); // ignore for now
 
 void CmiCallHandler(int handlerId, void *msg);
 
@@ -49,7 +47,7 @@ typedef struct State
 {
     int pe;
     int node;
-    ConverseQueue<CmiMessage> queue;
+    ConverseQueue<CmiMessage> *queue;
 
 } CmiState;
 

--- a/convcore.h
+++ b/convcore.h
@@ -25,13 +25,17 @@ typedef struct CmiMessageStruct
     char data[];
 } CmiMessage;
 
-// handler tools
+// handler functionality
+// TODO: what is CmiHandlerEx in old converse?
+
 typedef void (*CmiHandler)(void *msg);
 typedef void (*CmiHandlerEx)(void *msg, void *userPtr);
 
+void CmiCallHandler(int handlerId, void *msg);
+
 typedef struct HandlerInfo
 {
-    CmiHandlerEx hdlr;
+    CmiHandler hdlr;
     void *userPtr;
 } CmiHandlerInfo;
 
@@ -57,9 +61,11 @@ void CmiInitState(int pe);
 int CmiMyPE();
 int CmiMyNode();
 int CmiMyNodeSize();
+
 // message sending
 void CmiPushPE(int destPE, int messageSize, void *msg);
 void CmiSyncSendAndFree(int destPE, int messageSize, void *msg);
 
 void CmiNodeBarrier(void);
+
 #endif

--- a/convcore.h
+++ b/convcore.h
@@ -35,8 +35,6 @@ typedef struct HandlerInfo
     void *userPtr;
 } CmiHandlerInfo;
 
-static char **Cmi_argv;
-
 void CmiStartThreads(char **argv);
 
 void *converseRunPe(void *arg);
@@ -46,15 +44,14 @@ void *converseRunPe(void *arg);
 typedef struct State
 {
     int pe;
-    int rank;
+    int node;
     ConverseQueue<CmiMessage> queue;
 
 } CmiState;
 
 // state relevant functionality
-CmiState CmiGetState(void);
-CmiState CmiGetState(int pe);
-void CmiInitState();
+CmiState *CmiGetState(void);
+void CmiInitState(int pe);
 
 // state getters
 int CmiMyPE();

--- a/convcore.h
+++ b/convcore.h
@@ -23,7 +23,10 @@ typedef struct CmiMessageStruct
     char data[];
 } CmiMessage;
 
-// handler functionality
+void CmiStartThreads(char **argv);
+void *converseRunPe(void *arg);
+
+// HANDLERS
 // TODO: what is CmiHandlerEx in old converse?
 
 typedef void (*CmiHandler)(void *msg);
@@ -37,15 +40,13 @@ typedef struct HandlerInfo
     void *userPtr;
 } CmiHandlerInfo;
 
-void CmiStartThreads(char **argv);
-
-void *converseRunPe(void *arg);
+std::vector<CmiHandlerInfo> *CmiGetHandlerTable();
 
 /*Cmi Functions*/
 
 typedef struct State
 {
-    int pe;
+    int rank;
     int node;
     ConverseQueue<CmiMessage> *queue;
 
@@ -54,11 +55,7 @@ typedef struct State
 // state relevant functionality
 CmiState *CmiGetState(void);
 void CmiInitState(int pe);
-
-// state getters
-int CmiMyPE();
-int CmiMyNode();
-int CmiMyNodeSize();
+ConverseQueue<CmiMessage> *CmiGetQueue(int pe);
 
 // message sending
 void CmiPushPE(int destPE, int messageSize, void *msg);

--- a/convcore.h
+++ b/convcore.h
@@ -9,7 +9,7 @@ static CmiStartFn Cmi_startfn;
 int Cmi_npes;
 int Cmi_argc;
 
-static void CmiStartThreads(char **argv);
+void CmiStartThreads(char **argv);
 
 void *converseRunPe(void *arg);
 

--- a/convcore.h
+++ b/convcore.h
@@ -4,15 +4,13 @@
 #include "converse.h"
 #include "queue.h"
 
-static char **Cmi_argv;
+#include "CpvMacros.h"
+
+typedef void (*CmiStartFn)(int argc, char **argv);
+void ConverseInit(int argc, char **argv, CmiStartFn fn);
 
 static CmiStartFn Cmi_startfn;
 
-void CmiStartThreads(char **argv);
-
-void *converseRunPe(void *arg);
-
-/*Cmi Functions*/
 typedef struct Header
 {
     int handlerId;
@@ -21,13 +19,29 @@ typedef struct Header
     int destPE;
 } CmiMessageHeader;
 
-#define CmiMessageHeaderSize sizeof(CmiMessageHeader)
-
 typedef struct CmiMessageStruct
 {
     CmiMessageHeader header;
     char data[];
 } CmiMessage;
+
+// handler tools
+typedef void (*CmiHandler)(void *msg);
+typedef void (*CmiHandlerEx)(void *msg, void *userPtr);
+
+typedef struct HandlerInfo
+{
+    CmiHandlerEx hdlr;
+    void *userPtr;
+} CmiHandlerInfo;
+
+static char **Cmi_argv;
+
+void CmiStartThreads(char **argv);
+
+void *converseRunPe(void *arg);
+
+/*Cmi Functions*/
 
 typedef struct State
 {
@@ -45,9 +59,10 @@ void CmiInitState();
 // state getters
 int CmiMyPE();
 int CmiMyNode();
-
+int CmiMyNodeSize();
 // message sending
 void CmiPushPE(int destPE, int messageSize, void *msg);
 void CmiSyncSendAndFree(int destPE, int messageSize, void *msg);
 
+void CmiNodeBarrier(void);
 #endif

--- a/converse.h
+++ b/converse.h
@@ -10,3 +10,9 @@ typedef void (*CmiHandler)(void *msg);
 typedef void (*CmiHandlerEx)(void *msg, void *userPtr);
 
 int CmiRegisterHandler(CmiHandler h);
+
+// state getters
+int CmiMyPE();
+int CmiMyNode();
+int CmiMyNodeSize();
+int CmiMyRank();

--- a/converse.h
+++ b/converse.h
@@ -1,3 +1,2 @@
 typedef void (*CmiStartFn)(int argc, char **argv);
-
 void ConverseInit(int argc, char **argv, CmiStartFn fn);

--- a/converse.h
+++ b/converse.h
@@ -1,2 +1,12 @@
+#include "CpvMacros.h"
+
 typedef void (*CmiStartFn)(int argc, char **argv);
 void ConverseInit(int argc, char **argv, CmiStartFn fn);
+
+#define CmiMessageHeaderSize sizeof(CmiMessageHeader)
+
+// handler tools
+typedef void (*CmiHandler)(void *msg);
+typedef void (*CmiHandlerEx)(void *msg, void *userPtr);
+
+int CmiRegisterHandler(CmiHandler h);

--- a/converse.h
+++ b/converse.h
@@ -1,4 +1,4 @@
-#include "CpvMacros.h"
+#include "CpvMacros.h" // for backward compatibility
 
 typedef void (*CmiStartFn)(int argc, char **argv);
 void ConverseInit(int argc, char **argv, CmiStartFn fn);

--- a/examples/startup/Makefile
+++ b/examples/startup/Makefile
@@ -1,2 +1,23 @@
-test: startup.C ../../convcore.C ../../scheduler.C ../../queue.C
-	g++ -o test startup.C ../../convcore.C ../../scheduler.C ../../queue.C -I ../.. -std=c++11 -pthread
+# Compiler and flags
+CXX := g++
+CXXFLAGS := -std=c++11 -pthread -I ../..
+
+# Source files
+SRCS := startup.C ../../convcore.C ../../scheduler.C ../../queue.C
+HDRS := ../../convcore.h ../../scheduler.h ../../queue.h ../../barrier.h
+
+# Output executable
+TARGET := test
+
+# Default target
+all: $(TARGET)
+
+# Link the object files to create the executable
+$(TARGET): $(SRCS)
+	$(CXX) -o $@ $^ $(CXXFLAGS)
+
+# Clean up build files
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all clean

--- a/examples/startup/Makefile
+++ b/examples/startup/Makefile
@@ -1,2 +1,2 @@
 test: startup.C ../../convcore.C ../../scheduler.C
-	gcc -o test startup.C ../../convcore.C ../../scheduler.C -I ../..
+	g++ -o test startup.C ../../convcore.C ../../scheduler.C -I ../.. -std=c++11 -pthread

--- a/examples/startup/startup.C
+++ b/examples/startup/startup.C
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <pthread.h>
 
-CpvDeclare(int, test_mype);
+CpvDeclare(int, test);
 
 void ping_handler(void *vmsg)
 {
@@ -11,11 +11,11 @@ void ping_handler(void *vmsg)
 
 CmiStartFn mymain(int argc, char **argv)
 {
-  printf("Calling main, argc=%d\n", argc);
-  CpvInitialize(int, test_mype);
-  CpvAccess(test_mype) = CmiMyPE();
+  CpvInitialize(int, test);
+  CpvAccess(test) = 42;
 
-  printf("My PE is %d\n", CpvAccess(test_mype));
+  printf("My PE is %d\n", CmiMyPE());
+  printf("Answer to the Ultimate Question of Life, the Universe, and Everything: %d\n", CpvAccess(test));
   return 0;
 }
 

--- a/examples/startup/startup.C
+++ b/examples/startup/startup.C
@@ -2,9 +2,20 @@
 #include <stdio.h>
 #include <pthread.h>
 
+CpvDeclare(int, test_mype);
+
+void ping_handler(void *vmsg)
+{
+  printf("Ping handler called\n");
+}
+
 CmiStartFn mymain(int argc, char **argv)
 {
   printf("Calling main, argc=%d\n", argc);
+  CpvInitialize(int, test_mype);
+  CpvAccess(test_mype) = CmiMyPE();
+
+  printf("My PE is %d\n", CpvAccess(test_mype));
   return 0;
 }
 

--- a/examples/startup/startup.C
+++ b/examples/startup/startup.C
@@ -15,7 +15,41 @@ CmiStartFn mymain(int argc, char **argv)
   CpvAccess(test) = 42;
 
   printf("My PE is %d\n", CmiMyPE());
-  printf("Answer to the Ultimate Question of Life, the Universe, and Everything: %d\n", CpvAccess(test));
+
+  int handlerId = CmiRegisterHandler(ping_handler);
+
+  if (CmiMyPE() == 0 && CmiMyNodeSize() > 1)
+  {
+    // create a message
+    CmiMessage *msg = new CmiMessage;
+    msg->header.handlerId = handlerId;
+    msg->header.messageSize = sizeof(CmiMessage);
+    msg->header.destPE = 1;
+
+    // TODO: why is this info passed within message an also separately
+    int sendToPE = 1;
+
+    // Send from my pe-i on node-0 to q+i on node-1
+    CmiSyncSendAndFree(sendToPE, msg->header.messageSize, msg);
+  }
+
+  else if (CmiMyNodeSize() == 1)
+  {
+    printf("Only one node, send self test\n");
+    // create a message
+    CmiMessage *msg = new CmiMessage;
+    msg->header.handlerId = handlerId;
+    msg->header.messageSize = sizeof(CmiMessage);
+    msg->header.destPE = 1;
+
+    // TODO: why is this info passed within message an also separately
+    int sendToPE = 0;
+
+    // Send from my pe-i on node-0 to q+i on node-1
+    CmiSyncSendAndFree(sendToPE, msg->header.messageSize, msg);
+  }
+
+  // printf("Answer to the Ultimate Question of Life, the Universe, and Everything: %d\n", CpvAccess(test));
   return 0;
 }
 

--- a/examples/startup/startup.C
+++ b/examples/startup/startup.C
@@ -6,19 +6,19 @@ CpvDeclare(int, test);
 
 void ping_handler(void *vmsg)
 {
-  printf("Ping handler called\n");
+  printf("PING HANDLER CALLED\n");
 }
 
 CmiStartFn mymain(int argc, char **argv)
 {
-  CpvInitialize(int, test);
-  CpvAccess(test) = 42;
+  // CpvInitialize(int, test);
+  // CpvAccess(test) = 42;
 
-  printf("My PE is %d\n", CmiMyPE());
+  printf("My PE is %d\n", CmiMyRank());
 
   int handlerId = CmiRegisterHandler(ping_handler);
 
-  if (CmiMyPE() == 0 && CmiMyNodeSize() > 1)
+  if (CmiMyRank() == 0 && CmiMyNodeSize() > 1)
   {
     // create a message
     CmiMessage *msg = new CmiMessage;

--- a/examples/startup/startup.C
+++ b/examples/startup/startup.C
@@ -11,8 +11,8 @@ void ping_handler(void *vmsg)
 
 CmiStartFn mymain(int argc, char **argv)
 {
-  // CpvInitialize(int, test);
-  // CpvAccess(test) = 42;
+  CpvInitialize(int, test);
+  CpvAccess(test) = 42;
 
   printf("My PE is %d\n", CmiMyRank());
 

--- a/queue.C
+++ b/queue.C
@@ -1,4 +1,5 @@
 #include "queue.h"
+
 // Add MutexAccessControl implementation
 std::mutex MutexAccessControl::mutex;
 
@@ -11,4 +12,3 @@ void MutexAccessControl::release()
 {
     mutex.unlock();
 }
-

--- a/queue.h
+++ b/queue.h
@@ -3,30 +3,33 @@
 
 #include <queue>
 #include <mutex>
-class MutexAccessControl {
+class MutexAccessControl
+{
 public:
     static std::mutex mutex;
-    
-    static void acquire() {
+
+    static void acquire()
+    {
         mutex.lock();
     }
-    
-    static void release() {
+
+    static void release()
+    {
         mutex.unlock();
     }
 };
 
 std::mutex MutexAccessControl::mutex;
 
-
-
 // An MPSC queue that can be used to send messages between threads.
-template<typename ConcreteQ, typename MessageType, typename AccessControlPolicy>
-class MPSCQueue {
+template <typename ConcreteQ, typename MessageType, typename AccessControlPolicy>
+class MPSCQueue
+{
     ConcreteQ q;
 
 public:
-    MessageType pop() {
+    MessageType pop()
+    {
         AccessControlPolicy::acquire();
         // This will not work for atomics.
         // It's fine for now: internal implementation detail.
@@ -36,15 +39,15 @@ public:
         return message;
     }
 
-    void push(MessageType message) {
+    void push(MessageType message)
+    {
         AccessControlPolicy::acquire();
         q.push(message);
         AccessControlPolicy::release();
     }
-
 };
 
-template<typename MessageType>
-using ReconverseQueue = MPSCQueue<std::queue<MessageType>, MessageType, MutexAccessControl>;
+template <typename MessageType>
+using ConverseQueue = MPSCQueue<std::queue<MessageType>, MessageType, MutexAccessControl>;
 
 #endif

--- a/queue.h
+++ b/queue.h
@@ -3,6 +3,7 @@
 
 #include <queue>
 #include <mutex>
+#include <stdexcept>
 
 class MutexAccessControl
 {

--- a/queue.h
+++ b/queue.h
@@ -21,7 +21,6 @@ class MPSCQueue
 public:
     MessageType pop()
     {
-        printf("Popping message from queue\n");
         AccessControlPolicy::acquire();
         // This will not work for atomics.
         // It's fine for now: internal implementation detail.
@@ -40,7 +39,6 @@ public:
 
     void push(MessageType message)
     {
-        printf("Pushing message into queue\n");
         AccessControlPolicy::acquire();
         q.push(message);
         AccessControlPolicy::release();

--- a/queue.h
+++ b/queue.h
@@ -21,9 +21,17 @@ class MPSCQueue
 public:
     MessageType pop()
     {
+        printf("Popping message from queue\n");
         AccessControlPolicy::acquire();
         // This will not work for atomics.
         // It's fine for now: internal implementation detail.
+
+        if (q.size() == 0)
+        {
+            // TODO: throw something?
+            throw std::runtime_error("Cannot pop from empty queue is empty");
+        }
+
         MessageType message = q.front();
         q.pop();
         AccessControlPolicy::release();
@@ -32,6 +40,7 @@ public:
 
     void push(MessageType message)
     {
+        printf("Pushing message into queue\n");
         AccessControlPolicy::acquire();
         q.push(message);
         AccessControlPolicy::release();
@@ -39,6 +48,7 @@ public:
 
     bool empty()
     {
+
         return this->size() == 0;
     }
 
@@ -47,6 +57,7 @@ public:
         AccessControlPolicy::acquire();
         size_t result = q.size();
         AccessControlPolicy::release();
+
         return result;
     }
 };

--- a/scheduler.C
+++ b/scheduler.C
@@ -1,5 +1,17 @@
 #include "scheduler.h"
+#include "convcore.h"
+#include "queue.h"
 
 void CsdScheduler()
 {
+    // get pthread level queue
+    ConverseQueue<CmiMessage> queue = CmiGetState().queue;
+
+    while (true)
+    {
+        // get next event
+        // TODO: where is the check for empty queue?
+        CmiMessage message = queue.pop();
+        // process event
+    }
 }

--- a/scheduler.C
+++ b/scheduler.C
@@ -6,29 +6,25 @@
 void CsdScheduler()
 {
     // get pthread level queue
-    printf("DEBUG!! Starting scheduler\n");
-
-    ConverseQueue<CmiMessage> queue = CmiGetState()->queue;
+    ConverseQueue<CmiMessage> *queue = CmiGetState()->queue;
 
     while (true)
     {
-
-        if (!queue.empty())
+        if (!queue->empty())
         {
+            // get next event (guaranteed to be there because only single consumer)
+            CmiMessage message = queue->pop();
 
-            printf("Processing event\n");
-            // get next event
-            CmiMessage message = queue.pop();
-
-            // TODO: process event
+            // process event
             CmiMessageHeader header = message.header;
             int handler = header.handlerId;
 
+            // call handler
             CmiCallHandler(handler, message.data);
-
-            // CpvAccess(CmiHandlerTable)[handler].hdlr(message);
         }
+
+        // TODO: suspend? or spin?
     }
 }
 
-// TODO: implement CsdEnqueue: how does a PE get another PEs state/queue?
+// TODO: implement CsdEnqueue/Dequeue (why are these necessary?)

--- a/scheduler.C
+++ b/scheduler.C
@@ -6,7 +6,8 @@
 void CsdScheduler()
 {
     // get pthread level queue
-    ConverseQueue<CmiMessage> *queue = CmiGetState()->queue;
+
+    ConverseQueue<CmiMessage> *queue = CmiGetQueue(CmiMyRank());
 
     while (true)
     {

--- a/scheduler.C
+++ b/scheduler.C
@@ -5,7 +5,8 @@
 void CsdScheduler()
 {
     // get pthread level queue
-    ConverseQueue<CmiMessage> queue = CmiGetState().queue;
+
+    ConverseQueue<CmiMessage> queue = CmiGetState()->queue;
 
     while (true)
     {

--- a/scheduler.C
+++ b/scheduler.C
@@ -9,9 +9,18 @@ void CsdScheduler()
 
     while (true)
     {
+        if (queue.empty())
+        {
+            // wait for new event
+            // TODO: do we just spin? or is there a better way?
+            continue;
+        }
+
         // get next event
-        // TODO: where is the check for empty queue?
         CmiMessage message = queue.pop();
-        // process event
+
+        // TODO: process event
     }
 }
+
+// TODO: implement CsdEnqueue: how does a PE get another PEs state/queue?

--- a/scheduler.C
+++ b/scheduler.C
@@ -1,30 +1,33 @@
 #include "scheduler.h"
 #include "convcore.h"
 #include "queue.h"
+#include <thread>
 
 void CsdScheduler()
 {
     // get pthread level queue
+    printf("DEBUG!! Starting scheduler\n");
 
     ConverseQueue<CmiMessage> queue = CmiGetState()->queue;
 
     while (true)
     {
-        if (queue.empty())
+
+        if (!queue.empty())
         {
-            // wait for new event
-            // TODO: do we just spin? or is there a better way?
-            continue;
+
+            printf("Processing event\n");
+            // get next event
+            CmiMessage message = queue.pop();
+
+            // TODO: process event
+            CmiMessageHeader header = message.header;
+            int handler = header.handlerId;
+
+            CmiCallHandler(handler, message.data);
+
+            // CpvAccess(CmiHandlerTable)[handler].hdlr(message);
         }
-
-        // get next event
-        CmiMessage message = queue.pop();
-
-        // TODO: process event
-        CmiMessageHeader header = message.header;
-        int handler = header.handlerId;
-
-        // CpvAccess(CmiHandlerTable)[handler].hdlr(message);
     }
 }
 

--- a/scheduler.C
+++ b/scheduler.C
@@ -20,6 +20,10 @@ void CsdScheduler()
         CmiMessage message = queue.pop();
 
         // TODO: process event
+        CmiMessageHeader header = message.header;
+        int handler = header.handlerId;
+
+        // CpvAccess(CmiHandlerTable)[handler].hdlr(message);
     }
 }
 

--- a/test/queue.C
+++ b/test/queue.C
@@ -6,29 +6,33 @@
 #include <mutex>
 #include <assert.h>
 
-bool testSimplePushPop() {
-    ReconverseQueue<int> q;
+bool testSimplePushPop()
+{
+    ConverseQueue<int> q;
     q.push(1);
     q.push(2);
     q.push(3);
     return q.pop() == 1 && q.pop() == 2 && q.pop() == 3;
 }
 
-bool testMultiThreadedPushPop() {
-    ReconverseQueue<int> q;
+bool testMultiThreadedPushPop()
+{
+    ConverseQueue<int> q;
     const int NUM_THREADS = 10;
     const int ITEMS_PER_THREAD = 2000000;
-    
+
     // Barrier implementation using condition variable
     // std::barrier is not available in C++11
     std::mutex mutex;
     std::condition_variable cv;
     int count = 0;
     bool ready = false;
-    
+
     std::vector<std::thread> threads;
-    for (int t = 0; t < NUM_THREADS; t++) {
-        threads.push_back(std::thread([&, t]() {
+    for (int t = 0; t < NUM_THREADS; t++)
+    {
+        threads.push_back(std::thread([&, t]()
+                                      {
             {
                 std::unique_lock<std::mutex> lock(mutex);
                 count++;
@@ -43,28 +47,32 @@ bool testMultiThreadedPushPop() {
             // Push values
             for (int i = 0; i < ITEMS_PER_THREAD; i++) {
                 q.push(t * ITEMS_PER_THREAD + i);
-            }
-        }));
+            } }));
     }
-    
-    for (auto& thread : threads) {
+
+    for (auto &thread : threads)
+    {
         thread.join();
     }
-    
-    std::vector<int> values;    
-    for (int i = 0; i < NUM_THREADS * ITEMS_PER_THREAD; i++) {
+
+    std::vector<int> values;
+    for (int i = 0; i < NUM_THREADS * ITEMS_PER_THREAD; i++)
+    {
         values.push_back(q.pop());
     }
     std::sort(values.begin(), values.end());
-    for (int i = 0; i < NUM_THREADS * ITEMS_PER_THREAD; i++) {
-        if (values[i] != i) {
+    for (int i = 0; i < NUM_THREADS * ITEMS_PER_THREAD; i++)
+    {
+        if (values[i] != i)
+        {
             return false;
         }
     }
     return true;
 }
 
-int main() {
+int main()
+{
     assert(testSimplePushPop());
     assert(testMultiThreadedPushPop());
     return 0;

--- a/test/run_q_test.sh
+++ b/test/run_q_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-g++ -pthread queue.C -o qtest
+g++ queue.C ../queue.C -o qtest -std=c++11 -pthread -I ../
 ./qtest
 


### PR DESCRIPTION
The scheduler now supports handler registration and calling. This has only been tested with the current `startup.C`. This means it supports:
- multiple threads
- single handler registration
- single use of CmiSyncSendAndFree

Note: known bug - the Barrier (used in NodeBarrier) is single use only - calling it multiple times results in deadlock... If someone knows things about mutex use and can spot the bug that would be helpful :)