### PR TITLE
Support message data

### DIFF
--- a/convcore.C
+++ b/convcore.C
@@ -18,7 +18,7 @@ int Cmi_nranks;                                // TODO: this isnt used in old co
 std::vector<CmiHandlerInfo> **CmiHandlerTable; // array of handler vectors
 
 // PE LOCALS that need global access sometimes
-static ConverseQueue<CmiMessage *> **Cmi_queues; // array of queue pointers
+static ConverseQueue<void *> **Cmi_queues; // array of queue pointers
 
 // PE LOCALS
 thread_local int Cmi_myrank;
@@ -56,7 +56,7 @@ void CmiStartThreads()
     int threadPeNums[Cmi_npes];
 
     // allocate global arrayss
-    Cmi_queues = new ConverseQueue<CmiMessage *> *[Cmi_npes];
+    Cmi_queues = new ConverseQueue<void *> *[Cmi_npes];
     CmiHandlerTable = new std::vector<CmiHandlerInfo> *[Cmi_npes];
 
     for (int i = 0; i < Cmi_npes; i++)
@@ -111,14 +111,14 @@ void CmiInitState(int rank)
     Cmi_myrank = rank;
 
     // allocate global entries
-    ConverseQueue<CmiMessage *> *queue = new ConverseQueue<CmiMessage *>();
+    ConverseQueue<void *> *queue = new ConverseQueue<void *>();
     std::vector<CmiHandlerInfo> *handlerTable = new std::vector<CmiHandlerInfo>();
 
     Cmi_queues[Cmi_myrank] = queue;
     CmiHandlerTable[Cmi_myrank] = handlerTable;
 }
 
-ConverseQueue<CmiMessage *> *CmiGetQueue(int rank)
+ConverseQueue<void *> *CmiGetQueue(int rank)
 {
     return Cmi_queues[rank];
 }
@@ -155,7 +155,7 @@ std::vector<CmiHandlerInfo> *CmiGetHandlerTable()
 
 void CmiPushPE(int destPE, int messageSize, void *msg)
 {
-    Cmi_queues[destPE]->push((CmiMessage *)msg);
+    Cmi_queues[destPE]->push(msg);
 }
 
 void *CmiAlloc(int size)

--- a/convcore.h
+++ b/convcore.h
@@ -17,11 +17,11 @@ typedef struct Header
     int destPE;
 } CmiMessageHeader;
 
-typedef struct CmiMessageStruct
-{
-    CmiMessageHeader header;
-    char data[];
-} CmiMessage;
+// typedef struct CmiMessageStruct
+// {
+//     CmiMessageHeader header;
+//     char data[];
+// } CmiMessage;
 
 void CmiStartThreads(char **argv);
 void *converseRunPe(void *arg);
@@ -49,7 +49,7 @@ typedef struct State
     int pe;
     int rank;
     int node;
-    ConverseQueue<CmiMessage *> *queue;
+    ConverseQueue<void *> *queue;
     int stopFlag;
 
 } CmiState;
@@ -57,7 +57,7 @@ typedef struct State
 // state relevant functionality
 CmiState *CmiGetState(void);
 void CmiInitState(int pe);
-ConverseQueue<CmiMessage *> *CmiGetQueue(int pe);
+ConverseQueue<void *> *CmiGetQueue(int pe);
 
 // message allocation
 void *CmiAlloc(int size);

--- a/convcore.h
+++ b/convcore.h
@@ -49,7 +49,7 @@ typedef struct State
     int pe;
     int rank;
     int node;
-    ConverseQueue<CmiMessage> *queue;
+    ConverseQueue<CmiMessage *> *queue;
     int stopFlag;
 
 } CmiState;
@@ -57,11 +57,11 @@ typedef struct State
 // state relevant functionality
 CmiState *CmiGetState(void);
 void CmiInitState(int pe);
-ConverseQueue<CmiMessage> *CmiGetQueue(int pe);
+ConverseQueue<CmiMessage *> *CmiGetQueue(int pe);
 
-//message allocation
-void* CmiAlloc(int size);
-void CmiFree(void* msg);
+// message allocation
+void *CmiAlloc(int size);
+void CmiFree(void *msg);
 
 // message sending
 void CmiPushPE(int destPE, int messageSize, void *msg);

--- a/examples/broadcast/broadcast.C
+++ b/examples/broadcast/broadcast.C
@@ -4,6 +4,11 @@
 
 CpvDeclare(int, exitHandlerId);
 
+struct Message
+{
+  CmiMessageHeader header;
+};
+
 void stop_handler(void *vmsg)
 {
   CsdExitScheduler();
@@ -24,11 +29,11 @@ CmiStartFn mymain(int argc, char **argv)
   if (CmiMyPE() == 0)
   {
     // create a message
-    CmiMessage *msg = (CmiMessage*) CmiAlloc(sizeof(CmiMessage));
+    Message *msg = new Message;
     msg->header.handlerId = handlerId;
-    msg->header.messageSize = sizeof(CmiMessage);
-    
-    CmiSyncBroadcastAllAndFree(msg->header.messageSize, msg);     
+    msg->header.messageSize = sizeof(Message);
+
+    CmiSyncBroadcastAllAndFree(msg->header.messageSize, msg);
   }
 
   // printf("Answer to the Ultimate Question of Life, the Universe, and Everything: %d\n", CpvAccess(test));

--- a/examples/ring/Makefile
+++ b/examples/ring/Makefile
@@ -1,0 +1,23 @@
+# Compiler and flags
+CXX := g++
+CXXFLAGS := -std=c++11 -pthread -I ../..
+
+# Source files
+SRCS := startup.C ../../convcore.C ../../scheduler.C ../../queue.C
+HDRS := ../../convcore.h ../../scheduler.h ../../queue.h ../../barrier.h
+
+# Output executable
+TARGET := test
+
+# Default target
+all: $(TARGET)
+
+# Link the object files to create the executable
+$(TARGET): $(SRCS)
+	$(CXX) -o $@ $^ $(CXXFLAGS)
+
+# Clean up build files
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all clean

--- a/examples/ring/Makefile
+++ b/examples/ring/Makefile
@@ -3,7 +3,7 @@ CXX := g++
 CXXFLAGS := -std=c++11 -pthread -I ../..
 
 # Source files
-SRCS := startup.C ../../convcore.C ../../scheduler.C ../../queue.C
+SRCS := ring.C ../../convcore.C ../../scheduler.C ../../queue.C
 HDRS := ../../convcore.h ../../scheduler.h ../../queue.h ../../barrier.h
 
 # Output executable

--- a/examples/ring/ring.C
+++ b/examples/ring/ring.C
@@ -1,0 +1,76 @@
+#include "converse.h"
+#include <stdio.h>
+#include <pthread.h>
+
+CpvDeclare(int, test);
+CpvDeclare(int, exitHandlerId);
+
+int ping_handlerID;
+int payloadSize = 1 * sizeof(int);
+
+void stop_handler(void *vmsg)
+{
+  CsdExitScheduler();
+}
+
+void ping_handler(void *vmsg)
+{
+  CmiMessage *msg = (CmiMessage *)vmsg;
+  printf("PE %d pinged in ring with index %d.\n", CmiMyRank(), msg->data[0]);
+
+  if (CmiMyRank() != CmiMyNodeSize() - 1)
+  {
+    CmiMessage *newmsg = (CmiMessage *)CmiAlloc(sizeof(CmiMessage) + payloadSize);
+    newmsg->header.handlerId = ping_handlerID;
+    newmsg->header.messageSize = sizeof(CmiMessage) + payloadSize;
+    newmsg->header.destPE = CmiMyRank() + 1;
+
+    newmsg->data[0] = msg->data[0] + 1;
+    printf("PE %d sending to PE %d with data %d\n", CmiMyRank(), CmiMyRank() + 1, newmsg->data[0]);
+
+    CmiSyncSendAndFree(CmiMyRank() + 1, newmsg->header.messageSize, newmsg);
+  }
+  else
+  {
+    CmiMessage *msg = (CmiMessage *)CmiAlloc(sizeof(CmiMessage));
+    msg->header.handlerId = CpvAccess(exitHandlerId);
+    msg->header.messageSize = sizeof(CmiMessage);
+    CmiSyncBroadcastAllAndFree(msg->header.messageSize, msg);
+  }
+}
+
+CmiStartFn mymain(int argc, char **argv)
+{
+  CpvInitialize(int, test);
+  CpvAccess(test) = 42;
+
+  ping_handlerID = CmiRegisterHandler(ping_handler);
+
+  if (CmiMyRank() == 0)
+  {
+    // create a message
+    CmiMessage *msg = (CmiMessage *)CmiAlloc(sizeof(CmiMessage) + payloadSize);
+    msg->header.handlerId = ping_handlerID;
+    msg->header.messageSize = sizeof(CmiMessage) + payloadSize;
+    msg->header.destPE = 0;
+    msg->data[0] = 0;
+
+    // TODO: why is this info passed within message an also separately
+    int sendToPE = 0;
+
+    // Send from my pe-i on node-0 to q+i on node-1
+    CmiSyncSendAndFree(sendToPE, msg->header.messageSize, msg);
+  }
+
+  CpvInitialize(int, exitHandlerId);
+  CpvAccess(exitHandlerId) = CmiRegisterHandler(stop_handler);
+
+  // printf("Answer to the Ultimate Question of Life, the Universe, and Everything: %d\n", CpvAccess(test));
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  ConverseInit(argc, argv, (CmiStartFn)mymain);
+  return 0;
+}

--- a/examples/startup/startup.C
+++ b/examples/startup/startup.C
@@ -5,6 +5,11 @@
 CpvDeclare(int, test);
 CpvDeclare(int, exitHandlerId);
 
+struct Message
+{
+  CmiMessageHeader header;
+};
+
 void stop_handler(void *vmsg)
 {
   CsdExitScheduler();
@@ -13,11 +18,11 @@ void stop_handler(void *vmsg)
 void ping_handler(void *vmsg)
 {
   printf("PING HANDLER CALLED\n");
-  for(int i=0; i<CmiMyNodeSize(); i++)
+  for (int i = 0; i < CmiMyNodeSize(); i++)
   {
-    CmiMessage *msg = new CmiMessage;
+    Message *msg = new Message;
     msg->header.handlerId = CpvAccess(exitHandlerId);
-    msg->header.messageSize = sizeof(CmiMessage);
+    msg->header.messageSize = sizeof(Message);
     msg->header.destPE = i;
 
     CmiSyncSendAndFree(i, msg->header.messageSize, msg);
@@ -36,9 +41,9 @@ CmiStartFn mymain(int argc, char **argv)
   if (CmiMyRank() == 0 && CmiMyNodeSize() > 1)
   {
     // create a message
-    CmiMessage *msg = (CmiMessage*) CmiAlloc(sizeof(CmiMessage));
+    Message *msg = (Message *)CmiAlloc(sizeof(Message));
     msg->header.handlerId = handlerId;
-    msg->header.messageSize = sizeof(CmiMessage);
+    msg->header.messageSize = sizeof(Message);
     msg->header.destPE = 1;
 
     // TODO: why is this info passed within message an also separately
@@ -52,9 +57,9 @@ CmiStartFn mymain(int argc, char **argv)
   {
     printf("Only one node, send self test\n");
     // create a message
-    CmiMessage *msg = new CmiMessage;
+    Message *msg = new Message;
     msg->header.handlerId = handlerId;
-    msg->header.messageSize = sizeof(CmiMessage);
+    msg->header.messageSize = sizeof(Message);
     msg->header.destPE = 1;
 
     // TODO: why is this info passed within message an also separately

--- a/scheduler.C
+++ b/scheduler.C
@@ -7,21 +7,21 @@ void CsdScheduler()
 {
     // get pthread level queue
 
-    ConverseQueue<CmiMessage> *queue = CmiGetQueue(CmiMyRank());
+    ConverseQueue<CmiMessage *> *queue = CmiGetQueue(CmiMyRank());
 
     while (CmiStopFlag() == 0)
     {
         if (!queue->empty())
         {
             // get next event (guaranteed to be there because only single consumer)
-            CmiMessage message = queue->pop();
+            CmiMessage *msg = queue->pop();
 
             // process event
-            CmiMessageHeader header = message.header;
+            CmiMessageHeader header = msg->header;
             int handler = header.handlerId;
 
             // call handler
-            CmiCallHandler(handler, message.data);
+            CmiCallHandler(handler, msg);
         }
 
         // TODO: suspend? or spin?

--- a/scheduler.C
+++ b/scheduler.C
@@ -7,18 +7,19 @@ void CsdScheduler()
 {
     // get pthread level queue
 
-    ConverseQueue<CmiMessage *> *queue = CmiGetQueue(CmiMyRank());
+    ConverseQueue<void *> *queue = CmiGetQueue(CmiMyRank());
 
     while (CmiStopFlag() == 0)
     {
         if (!queue->empty())
         {
             // get next event (guaranteed to be there because only single consumer)
-            CmiMessage *msg = queue->pop();
+            void *msg = queue->pop();
 
             // process event
-            CmiMessageHeader header = msg->header;
-            int handler = header.handlerId;
+            CmiMessageHeader *header = (CmiMessageHeader *)msg;
+            void *data = (void *)((char *)msg + CmiMessageHeaderSize);
+            int handler = header->handlerId;
 
             // call handler
             CmiCallHandler(handler, msg);


### PR DESCRIPTION
Removing the internal CmiMessage structure. Users are responsible for creating their own message struct and ensuring that the header is the first thing in the struct.