### PR TITLE
include cstdarg to fix compilation error

### DIFF
--- a/convcore.C
+++ b/convcore.C
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <vector>
 #include <cstring>
+#include <cstdarg>
 
 // GLOBALS
 int Cmi_argc;


### PR DESCRIPTION
Otherwise the code will complain "cannot find `va_start`"