### PR TITLE
Add the comm_backend layer and LCI1 implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,35 +44,26 @@ add_subdirectory(comm_backend)
 # ##############################################################################
 
 # LCI1
-find_package(
-  LCI
-  CONFIG
-  HINTS
-  ${LCI_ROOT}
-  $ENV{LCI_ROOT}
-  PATH_SUFFIXES
-  lib/cmake
-  lib64/cmake)
-if(RECONVERSE_TRY_ENABLE_COMM_LCI1
-   AND NOT LCI_WITH_LCT_ONLY
-   AND LCI_VERSION VERSION_LESS 2.0.0)
-  set(RECONVERSE_ENABLE_COMM_LCI1 ON)
-  target_link_libraries(reconverse PRIVATE LCI::LCI)
-  target_sources(reconverse PRIVATE comm_backend/lci1/comm_backend_lci1.C)
-else()
-  message(WARNING "LCI is not found. The LCI backend if not enabled.")
+if(RECONVERSE_TRY_ENABLE_COMM_LCI1)
+  find_package(
+    LCI
+    CONFIG
+    HINTS
+    ${LCI_ROOT}
+    $ENV{LCI_ROOT}
+    PATH_SUFFIXES
+    lib/cmake
+    lib64/cmake)
+  if(LCI_FOUND
+    AND NOT LCI_WITH_LCT_ONLY
+    AND LCI_VERSION VERSION_LESS 2.0.0)
+    set(RECONVERSE_ENABLE_COMM_LCI1 ON)
+    target_link_libraries(reconverse PRIVATE LCI::LCI)
+    target_sources(reconverse PRIVATE comm_backend/lci1/comm_backend_lci1.C)
+  else()
+    message(WARNING "LCI is not found. The LCI backend if not enabled.")
+  endif()
 endif()
-
-# LCI2
-# if(LCW_TRY_ENABLE_COMM_LCI2
-#    AND NOT LCI_WITH_LCT_ONLY
-#    AND LCI_VERSION VERSION_GREATER_EQUAL 2.0.0)
-#   set(LCW_ENABLE_BACKEND_LCI2 ON)
-#   target_link_libraries(reconverse PRIVATE LCI::LCI)
-#   target_sources(reconverse PRIVATE lci2/comm_backend_lci2.C)
-# else()
-#   message(WARNING "LCI2 is not found. The LCI2 backend if not enabled.")
-# endif()
 
 # ##############################################################################
 # Configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(RECONVERSE_TRY_ENABLE_COMM_LCI1)
     target_link_libraries(reconverse PRIVATE LCI::LCI)
     target_sources(reconverse PRIVATE comm_backend/lci1/comm_backend_lci1.C)
   else()
-    message(WARNING "LCI is not found. The LCI backend if not enabled.")
+    message(WARNING "LCI is not found. The LCI backend is not enabled.")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(RECONVERSE_BUILD_EXAMPLES "Build examples" ON)
 option(RECONVERSE_BUILD_TESTS "Build tests" ON)
 
+option(RECONVERSE_TRY_ENABLE_COMM_LCI1 "whether to enable the LCIv1 backend" ON)
+# option(LCW_TRY_ENABLE_COMM_LCI2 "whether to enable the LCIv2 backend" ON)
+
 # ##############################################################################
 # Add Library
 # ##############################################################################
@@ -32,8 +35,51 @@ find_package(Threads REQUIRED)
 add_library(reconverse)
 set_target_properties(reconverse PROPERTIES CXX_STANDARD 11)
 target_include_directories(reconverse PUBLIC .)
-target_sources(reconverse PRIVATE conv-conds.C convcore.C queue.C scheduler.C)
+target_sources(reconverse PRIVATE conv-conds.C convcore.C queue.C scheduler.C comm_backend/comm_backend_internal.C)
 target_link_libraries(reconverse PUBLIC Threads::Threads)
+add_subdirectory(comm_backend)
+
+# ##############################################################################
+# Communication Backends
+# ##############################################################################
+
+# LCI1
+find_package(
+  LCI
+  CONFIG
+  HINTS
+  ${LCI_ROOT}
+  $ENV{LCI_ROOT}
+  PATH_SUFFIXES
+  lib/cmake
+  lib64/cmake)
+if(RECONVERSE_TRY_ENABLE_COMM_LCI1
+   AND NOT LCI_WITH_LCT_ONLY
+   AND LCI_VERSION VERSION_LESS 2.0.0)
+  set(RECONVERSE_ENABLE_COMM_LCI1 ON)
+  target_link_libraries(reconverse PRIVATE LCI::LCI)
+  target_sources(reconverse PRIVATE comm_backend/lci1/comm_backend_lci1.C)
+else()
+  message(WARNING "LCI is not found. The LCI backend if not enabled.")
+endif()
+
+# LCI2
+# if(LCW_TRY_ENABLE_COMM_LCI2
+#    AND NOT LCI_WITH_LCT_ONLY
+#    AND LCI_VERSION VERSION_GREATER_EQUAL 2.0.0)
+#   set(LCW_ENABLE_BACKEND_LCI2 ON)
+#   target_link_libraries(reconverse PRIVATE LCI::LCI)
+#   target_sources(reconverse PRIVATE lci2/comm_backend_lci2.C)
+# else()
+#   message(WARNING "LCI2 is not found. The LCI2 backend if not enabled.")
+# endif()
+
+# ##############################################################################
+# Configure
+# ##############################################################################
+configure_file(converse_config.h.in ${CMAKE_BINARY_DIR}/converse_config.h)
+target_include_directories(reconverse PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+                                              $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # ##############################################################################
 # Add Subdirectories

--- a/CpvMacros.h
+++ b/CpvMacros.h
@@ -14,7 +14,7 @@
 #define CpvInitialize(t, v)                            \
     do                                                 \
     {                                                  \
-        if (CmiMyPe())                                 \
+        if (false /* I don't understand */)            \
         {                                              \
             CmiNodeBarrier();                          \
         }                                              \
@@ -26,6 +26,6 @@
     } while (0)
 ;
 
-#define CpvAccess(v) CMK_TAG(Cpv_, v)[CmiMyPe()]
+#define CpvAccess(v) CMK_TAG(Cpv_, v)[CmiMyRank()]
 
 #endif

--- a/README.md
+++ b/README.md
@@ -3,12 +3,32 @@ Basic implementation of a new communication layer for Charm++
 
 ## Install and run
 
+If you want to run Reconverse locally (single node), all you have to do is the following:  
+
 ```
 $ cd reconverse
 $ mkdir build
 $ cd build
+$ cmake -DRECONVERSE_TRY_ENABLE_COMM_LCI1=OFF ..
+$ make
+```
+
+If you want to run Reconverse in multi-node mode, you first need to install LCI (https://github.com/uiuc-hpc/lci). Note that multi-node is currently only supported on Linux-based systems.  
+Building multi-node Reconverse may be different based on your platform. Here is an example build procedure on NCSA's Delta machine using the OFI layer:  
+
+```
+$ git clone https://github.com/uiuc-hpc/lci.git
+$ cd lci
+$ export CMAKE_INSTALL_PREFIX=/u/<username> (or somewhere else you prefer)
+$ export OFI_ROOT=/opt/cray/libfabric/1.15.2.0
+$ cmake -DLCI_SERVER=ofi .
+$ make intall
+$ cd ..
+$ git clone https://github.com/charmplusplus/reconverse.git
+$ cd reconverse
+$ mkdir build && cd build
 $ cmake ..
 $ make
 ```
 
-In the build/examples/<program_name> folder, run the `reconverse_<program_name>` executable.
+In the build/examples/<program_name> folder, run the `reconverse_<program_name>` executable. Currently, the first arguments must be `+pe <num_pes>`.  

--- a/comm_backend/CMakeLists.txt
+++ b/comm_backend/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_include_directories(reconverse PUBLIC .)

--- a/comm_backend/comm_backend.h
+++ b/comm_backend/comm_backend.h
@@ -6,7 +6,7 @@
 namespace comm_backend {
 
 struct Status {
-    char *msg;
+    void* msg;
     size_t size;
 };
 using CompHandler = void (*)(Status status);
@@ -15,19 +15,27 @@ using AmHandler = int;
 /**
  * @brief Initialize the communication backend. Not thread-safe.
  */
-void init(int *argc, char ***argv, int *numNodes, int *myNodeID);
+void init(int *argc, char ***argv);
 /**
  * @brief Finalize the communication backend. Not thread-safe.
  */
 void exit();
 /**
+ * @brief Get the node ID of the current process. Thread-safe.
+ */
+int getMyNodeId();
+/**
+ * @brief Get the number of nodes in the system. Thread-safe.
+ */
+int getNumNodes();
+/**
  * @brief Register an active message handler. Not thread-safe.
  */
-AmHandler registerAmHandlerr(CompHandler handler);
+AmHandler registerAmHandler(CompHandler handler);
 /**
  * @brief Send an active message. Thread-safe.
  */
-void sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp);
+void sendAm(int rank, void *msg, size_t size, CompHandler localComp, AmHandler remoteComp);
 /**
  * @brief Make progress on the communication backend. Thread-safe.
  */

--- a/comm_backend/comm_backend.h
+++ b/comm_backend/comm_backend.h
@@ -1,0 +1,42 @@
+#ifndef RECONVERSE_COMM_BACKEND_H
+#define RECONVERSE_COMM_BACKEND_H
+
+#include <cstddef>
+
+namespace comm_backend {
+
+struct Status {
+    char *msg;
+    size_t size;
+};
+using CompHandler = void (*)(Status status);
+using AmHandler = int;
+
+/**
+ * @brief Initialize the communication backend. Not thread-safe.
+ */
+void init(int *argc, char ***argv, int *numNodes, int *myNodeID);
+/**
+ * @brief Finalize the communication backend. Not thread-safe.
+ */
+void exit();
+/**
+ * @brief Register an active message handler. Not thread-safe.
+ */
+AmHandler registerAmHandlerr(CompHandler handler);
+/**
+ * @brief Send an active message. Thread-safe.
+ */
+void sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp);
+/**
+ * @brief Make progress on the communication backend. Thread-safe.
+ */
+bool progress(void);
+/**
+ * @brief Block until all nodes have reached this point. Thread-safe.
+ */
+void barrier(void);
+
+} // namespace comm_backend
+
+#endif // RECONVERSE_COMM_BACKEND_H

--- a/comm_backend/comm_backend_internal.C
+++ b/comm_backend/comm_backend_internal.C
@@ -42,7 +42,6 @@ int getNumNodes()
 AmHandler registerAmHandler(CompHandler handler)
 {
   if (gCommBackend == nullptr) {
-    fprintf(stderr, "Error: commBackend is null\n");
     return -1;
   }
   return gCommBackend->registerAmHandler(handler);
@@ -51,7 +50,6 @@ AmHandler registerAmHandler(CompHandler handler)
 void sendAm(int rank, void* msg, size_t size, CompHandler localComp, AmHandler remoteComp)
 {
   if (gCommBackend == nullptr) {
-    fprintf(stderr, "Error: commBackend is null\n");
     return;
   }
   gCommBackend->sendAm(rank, msg, size, localComp, remoteComp);
@@ -60,7 +58,6 @@ void sendAm(int rank, void* msg, size_t size, CompHandler localComp, AmHandler r
 bool progress(void)
 {
   if (gCommBackend == nullptr) {
-    fprintf(stderr, "Error: commBackend is null\n");
     return false;
   }
   return gCommBackend->progress();
@@ -69,7 +66,6 @@ bool progress(void)
 void barrier(void)
 {
   if (gCommBackend == nullptr) {
-    fprintf(stderr, "Error: commBackend is null\n");
     return;
   }
   gCommBackend->barrier();

--- a/comm_backend/comm_backend_internal.C
+++ b/comm_backend/comm_backend_internal.C
@@ -1,0 +1,67 @@
+#include "comm_backend/comm_backend_internal.h"
+
+namespace comm_backend {
+
+CommBackendBase *commBackend = nullptr;
+
+void init(int *argc, char ***argv, int *numNodes, int *myNodeID) 
+{
+#ifdef RECONVERSE_ENABLE_COMM_LCI1
+  commBackend = new CommBackendLCI1();
+#endif
+  if (commBackend == nullptr) {
+    *numNodes = 1;
+    *myNodeID = 0;
+    return;
+  }
+  
+  commBackend->init(argc, argv, numNodes, myNodeID);
+}
+
+void exit()
+{
+  if (commBackend == nullptr) {
+    fprintf(stderr, "Error: commBackend is null\n");
+    return;
+  }
+  commBackend->exit();
+  delete commBackend;
+}
+
+AmHandler registerAmHandlerr(CompHandler handler)
+{
+  if (commBackend == nullptr) {
+    fprintf(stderr, "Error: commBackend is null\n");
+    return -1;
+  }
+  return commBackend->registerAmHandler(handler);
+}
+
+void sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp)
+{
+  if (commBackend == nullptr) {
+    fprintf(stderr, "Error: commBackend is null\n");
+    return;
+  }
+  commBackend->sendAm(rank, msg, size, localComp, remoteComp);
+}
+
+bool progress(void)
+{
+  if (commBackend == nullptr) {
+    fprintf(stderr, "Error: commBackend is null\n");
+    return false;
+  }
+  return commBackend->progress();
+}
+
+void barrier(void)
+{
+  if (commBackend == nullptr) {
+    fprintf(stderr, "Error: commBackend is null\n");
+    return;
+  }
+  commBackend->barrier();
+}
+
+} // namespace comm_backend

--- a/comm_backend/comm_backend_internal.h
+++ b/comm_backend/comm_backend_internal.h
@@ -1,0 +1,30 @@
+#ifndef COMM_BACKEND_INTERNAL_H
+#define COMM_BACKEND_INTERNAL_H
+
+#include <cstdio>
+#include <vector>
+
+#include "converse_config.h"
+#include "comm_backend/comm_backend.h"
+
+namespace comm_backend {
+
+class CommBackendBase 
+{
+ public:
+  virtual void init(int *argc, char ***argv, int *numNodes, int *myNodeID) = 0;
+  virtual void exit() = 0;
+  virtual AmHandler registerAmHandler(CompHandler handler) = 0;
+  virtual void sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp) = 0;
+  // return true if there is more work to do
+  virtual bool progress(void) = 0;
+  virtual void barrier(void) = 0;
+};
+
+} // namespace comm_backend
+
+#ifdef RECONVERSE_ENABLE_COMM_LCI1
+#include "comm_backend/lci1/comm_backend_lci1.h"
+#endif
+
+#endif // COMM_BACKEND_INTERNAL_H

--- a/comm_backend/comm_backend_internal.h
+++ b/comm_backend/comm_backend_internal.h
@@ -12,10 +12,12 @@ namespace comm_backend {
 class CommBackendBase 
 {
  public:
-  virtual void init(int *argc, char ***argv, int *numNodes, int *myNodeID) = 0;
+  virtual void init(int *argc, char ***argv) = 0;
   virtual void exit() = 0;
+  virtual int getMyNodeId() = 0;
+  virtual int getNumNodes() = 0;
   virtual AmHandler registerAmHandler(CompHandler handler) = 0;
-  virtual void sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp) = 0;
+  virtual void sendAm(int rank, void *msg, size_t size, CompHandler localComp, AmHandler remoteComp) = 0;
   // return true if there is more work to do
   virtual bool progress(void) = 0;
   virtual void barrier(void) = 0;

--- a/comm_backend/lci1/comm_backend_lci1.C
+++ b/comm_backend/lci1/comm_backend_lci1.C
@@ -111,6 +111,9 @@ void CommBackendLCI1::sendAm(int rank, void* msg, size_t size, CompHandler local
       buffer.segment = LCI_SEGMENT_ALL;
       ret = LCI_putla(m_ep, buffer, m_local_comp, rank, remoteComp, LCI_DEFAULT_COMP_REMOTE, reinterpret_cast<void*>(localComp));
     }
+    if (ret == LCI_ERR_RETRY) {
+      progress();
+    }
   } while (ret == LCI_ERR_RETRY);
 }
 

--- a/comm_backend/lci1/comm_backend_lci1.C
+++ b/comm_backend/lci1/comm_backend_lci1.C
@@ -1,10 +1,13 @@
 #include "comm_backend_internal.h"
+#include <cstring>
 
 #define LCI_SAFECALL(stmt)                                                    \
   do {                                                                        \
     int lci_errno = (stmt);                                                   \
-    if (LCI_OK != lci_errno)                                                  \
+    if (LCI_OK != lci_errno) {                                                \
       fprintf(stderr, "LCI call failed with %d \n", lci_errno);               \
+      abort();                                                                \
+    }                                                                         \
   } while (0)
 
 namespace comm_backend {
@@ -30,29 +33,55 @@ void remote_callback(LCI_request_t request)
 {
   auto am_handler = static_cast<AmHandler>(request.tag);
   auto handler = g_handlers[am_handler];
-  void *address;
   size_t size;
   if (request.type == LCI_MEDIUM) {
-    address = request.data.mbuffer.address;
     size = request.data.mbuffer.length;
   } else {
-    address = request.data.lbuffer.address;
     size = request.data.lbuffer.length;
+  }
+  void *address = malloc(size);
+  if (request.type == LCI_MEDIUM) {
+    std::memcpy(address, request.data.mbuffer.address, size);
+    LCI_mbuffer_free(request.data.mbuffer);
+  } else {
+    std::memcpy(address, request.data.lbuffer.address, size);
+    LCI_lbuffer_free(request.data.lbuffer);
   }
   handler({static_cast<char*>(address), size});
 }
 
-void CommBackendLCI1::init(int *argc, char ***argv, int *numNodes, int *myNodeID)
+void CommBackendLCI1::init(int *argc, char ***argv)
 {
   int initialized = false;
   LCI_SAFECALL(LCI_initialized(&initialized));
   if (!initialized)
     LCI_SAFECALL(LCI_initialize());
+
+  LCI_SAFECALL(LCI_handler_create(LCI_UR_DEVICE, local_callback, &m_local_comp));
+  LCI_SAFECALL(LCI_handler_create(LCI_UR_DEVICE, remote_callback, &m_remote_comp));
+  LCI_plist_t plist;
+  LCI_SAFECALL(LCI_plist_create(&plist));
+  LCI_SAFECALL(LCI_plist_set_comp_type(plist, LCI_PORT_COMMAND, LCI_COMPLETION_HANDLER));
+  LCI_SAFECALL(LCI_plist_set_comp_type(plist, LCI_PORT_MESSAGE, LCI_COMPLETION_HANDLER));
+  LCI_SAFECALL(LCI_plist_set_default_comp(plist, m_remote_comp));
+  LCI_SAFECALL(LCI_endpoint_init(&m_ep, LCI_UR_DEVICE, plist));
+  LCI_SAFECALL(LCI_plist_free(&plist));
 }
 
 void CommBackendLCI1::exit()
 {
+  LCI_SAFECALL(LCI_endpoint_free(&m_ep));
   LCI_SAFECALL(LCI_finalize());
+}
+
+int CommBackendLCI1::getMyNodeId()
+{
+  return LCI_RANK;
+}
+
+int CommBackendLCI1::getNumNodes()
+{
+  return LCI_NUM_PROCESSES;
 }
 
 AmHandler CommBackendLCI1::registerAmHandler(CompHandler handler)
@@ -61,7 +90,7 @@ AmHandler CommBackendLCI1::registerAmHandler(CompHandler handler)
   return g_handlers.size() - 1;
 }
 
-void CommBackendLCI1::sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp)
+void CommBackendLCI1::sendAm(int rank, void* msg, size_t size, CompHandler localComp, AmHandler remoteComp)
 {
   // we use LCI tag to pass the remoteComp
   LCI_error_t ret;
@@ -70,7 +99,7 @@ void CommBackendLCI1::sendAm(int rank, char *msg, size_t size, CompHandler local
       LCI_mbuffer_t buffer;
       buffer.address = msg;
       buffer.length = size;
-      auto ret = LCI_putma(LCI_UR_ENDPOINT, buffer, rank, remoteComp, LCI_DEFAULT_COMP_REMOTE);
+      ret = LCI_putma(m_ep, buffer, rank, remoteComp, LCI_DEFAULT_COMP_REMOTE);
       if (ret == LCI_OK) {
         // eager put is immediately completed.
         localComp({msg, size});
@@ -80,8 +109,7 @@ void CommBackendLCI1::sendAm(int rank, char *msg, size_t size, CompHandler local
       buffer.address = msg;
       buffer.length = size;
       buffer.segment = LCI_SEGMENT_ALL;
-      LCI_comp_t completion;
-      auto ret = LCI_putla(LCI_UR_ENDPOINT, buffer, completion, rank, remoteComp, LCI_DEFAULT_COMP_REMOTE, reinterpret_cast<void*>(localComp));
+      ret = LCI_putla(m_ep, buffer, m_local_comp, rank, remoteComp, LCI_DEFAULT_COMP_REMOTE, reinterpret_cast<void*>(localComp));
     }
   } while (ret == LCI_ERR_RETRY);
 }
@@ -96,6 +124,5 @@ void CommBackendLCI1::barrier(void)
 {
   LCI_SAFECALL(LCI_barrier());
 }
-
 
 } // namespace comm_backend

--- a/comm_backend/lci1/comm_backend_lci1.C
+++ b/comm_backend/lci1/comm_backend_lci1.C
@@ -1,0 +1,101 @@
+#include "comm_backend_internal.h"
+
+#define LCI_SAFECALL(stmt)                                                    \
+  do {                                                                        \
+    int lci_errno = (stmt);                                                   \
+    if (LCI_OK != lci_errno)                                                  \
+      fprintf(stderr, "LCI call failed with %d \n", lci_errno);               \
+  } while (0)
+
+namespace comm_backend {
+
+std::vector<CompHandler> g_handlers;
+
+void local_callback(LCI_request_t request)
+{
+  auto handler = reinterpret_cast<CompHandler>(request.user_context);
+  void *address;
+  size_t size;
+  if (request.type == LCI_MEDIUM) {
+    address = request.data.mbuffer.address;
+    size = request.data.mbuffer.length;
+  } else {
+    address = request.data.lbuffer.address;
+    size = request.data.lbuffer.length;
+  }
+  handler({static_cast<char*>(address), size});
+}
+
+void remote_callback(LCI_request_t request)
+{
+  auto am_handler = static_cast<AmHandler>(request.tag);
+  auto handler = g_handlers[am_handler];
+  void *address;
+  size_t size;
+  if (request.type == LCI_MEDIUM) {
+    address = request.data.mbuffer.address;
+    size = request.data.mbuffer.length;
+  } else {
+    address = request.data.lbuffer.address;
+    size = request.data.lbuffer.length;
+  }
+  handler({static_cast<char*>(address), size});
+}
+
+void CommBackendLCI1::init(int *argc, char ***argv, int *numNodes, int *myNodeID)
+{
+  int initialized = false;
+  LCI_SAFECALL(LCI_initialized(&initialized));
+  if (!initialized)
+    LCI_SAFECALL(LCI_initialize());
+}
+
+void CommBackendLCI1::exit()
+{
+  LCI_SAFECALL(LCI_finalize());
+}
+
+AmHandler CommBackendLCI1::registerAmHandler(CompHandler handler)
+{
+  g_handlers.push_back(handler);
+  return g_handlers.size() - 1;
+}
+
+void CommBackendLCI1::sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp)
+{
+  // we use LCI tag to pass the remoteComp
+  LCI_error_t ret;
+  do {
+    if (size <= LCI_MEDIUM_SIZE) {
+      LCI_mbuffer_t buffer;
+      buffer.address = msg;
+      buffer.length = size;
+      auto ret = LCI_putma(LCI_UR_ENDPOINT, buffer, rank, remoteComp, LCI_DEFAULT_COMP_REMOTE);
+      if (ret == LCI_OK) {
+        // eager put is immediately completed.
+        localComp({msg, size});
+      }
+    } else {
+      LCI_lbuffer_t buffer;
+      buffer.address = msg;
+      buffer.length = size;
+      buffer.segment = LCI_SEGMENT_ALL;
+      LCI_comp_t completion;
+      auto ret = LCI_putla(LCI_UR_ENDPOINT, buffer, completion, rank, remoteComp, LCI_DEFAULT_COMP_REMOTE, reinterpret_cast<void*>(localComp));
+    }
+  } while (ret == LCI_ERR_RETRY);
+}
+
+bool CommBackendLCI1::progress(void)
+{
+  auto ret = LCI_progress(LCI_UR_DEVICE);
+  return ret == LCI_OK;
+}
+
+void CommBackendLCI1::barrier(void)
+{
+  LCI_SAFECALL(LCI_barrier());
+}
+
+
+} // namespace comm_backend

--- a/comm_backend/lci1/comm_backend_lci1.h
+++ b/comm_backend/lci1/comm_backend_lci1.h
@@ -9,12 +9,18 @@ namespace comm_backend
 class CommBackendLCI1 : public CommBackendBase
 {
  public:
-  void init(int *argc, char ***argv, int *numNodes, int *myNodeID) override;
+  void init(int *argc, char ***argv) override;
   void exit() override;
+  int getMyNodeId() override;
+  int getNumNodes() override;
   AmHandler registerAmHandler(CompHandler handler) override;
-  void sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp) override;
+  void sendAm(int rank, void* msg, size_t size, CompHandler localComp, AmHandler remoteComp) override;
   bool progress(void) override;
   void barrier(void) override;
+ private:
+  LCI_comp_t m_local_comp;
+  LCI_comp_t m_remote_comp;
+  LCI_endpoint_t m_ep;
 };
 
 } // namespace comm_backend

--- a/comm_backend/lci1/comm_backend_lci1.h
+++ b/comm_backend/lci1/comm_backend_lci1.h
@@ -1,0 +1,22 @@
+#ifndef RECONVERSE_COMM_BACKEND_LCI1_H
+#define RECONVERSE_COMM_BACKEND_LCI1_H
+
+#include "lci.h"
+
+namespace comm_backend
+{
+
+class CommBackendLCI1 : public CommBackendBase
+{
+ public:
+  void init(int *argc, char ***argv, int *numNodes, int *myNodeID) override;
+  void exit() override;
+  AmHandler registerAmHandler(CompHandler handler) override;
+  void sendAm(int rank, char *msg, size_t size, CompHandler localComp, AmHandler remoteComp) override;
+  bool progress(void) override;
+  void barrier(void) override;
+};
+
+} // namespace comm_backend
+
+#endif // RECONVERSE_COMM_BACKEND_LCI1_H

--- a/convcore.C
+++ b/convcore.C
@@ -104,9 +104,6 @@ void ConverseInit(int argc, char **argv, CmiStartFn fn, int usched, int initret)
     Cmi_npes = atoi(argv[2]);
     // int plusPSet = CmiGetArgInt(argv,"+pe",&Cmi_npes);
 
-    // NOTE: calling CmiNumPes() here it sometimes returns zero
-    printf("Charm++> Running in SMP mode: %d processes\n", Cmi_npes);
-
     Cmi_argc = argc - 2; // TODO: Cmi_argc doesn't include runtime args?
     Cmi_argv = (char **)malloc(sizeof(char *) * (argc + 1));
     int i;
@@ -127,6 +124,9 @@ void ConverseInit(int argc, char **argv, CmiStartFn fn, int usched, int initret)
         fprintf(stderr, "Error: Number of PEs must be a multiple of number of nodes\n");
         exit(1);
     }
+    if (Cmi_mynode == 0)
+      printf("Charm++> Running in SMP mode on %d nodes and %d PEs\n",
+             Cmi_numnodes, Cmi_npes);
     Cmi_mynodesize = Cmi_npes / Cmi_numnodes;
     Cmi_nodestart = Cmi_mynode * Cmi_mynodesize;
     // register am handlers

--- a/convcore.C
+++ b/convcore.C
@@ -10,12 +10,17 @@
 #include <vector>
 #include <cstring>
 #include <cstdarg>
+#include <thread>
 
 // GLOBALS
 int Cmi_argc;
 static char **Cmi_argv;
 int Cmi_npes;
 int Cmi_nranks;                                // TODO: this isnt used in old converse, but we need to know how many PEs are on our node?
+int Cmi_mynode;
+int Cmi_mynodesize;
+int Cmi_numnodes;
+int Cmi_nodestart;
 std::vector<CmiHandlerInfo> **CmiHandlerTable; // array of handler vectors
 ConverseNodeQueue<void *> *CmiNodeQueue;
 double Cmi_startTime;
@@ -32,16 +37,33 @@ thread_local double idle_time;
 
 // TODO: padding for all these thread_locals and cmistates?
 
+comm_backend::AmHandler AmHandlerPE;
+comm_backend::AmHandler AmHandlerNode;
+
+void CommLocalHandler(comm_backend::Status status)
+{
+    CmiFree(status.msg);
+}
+
+void CommRemoteHandlerPE(comm_backend::Status status) {
+    CmiMessageHeader *header = (CmiMessageHeader *)status.msg;
+    int destPE = header->destPE;
+    CmiPushPE(destPE, status.size, status.msg);
+}
+
+void CommRemoteHandlerNode(comm_backend::Status status) {
+    CmiNodeQueue->push(status.msg);
+}
+
 void CmiCallHandler(int handler, void *msg)
 {
     CmiGetHandlerTable()->at(handler).hdlr(msg);
 }
 
-void *converseRunPe(void *args)
+void converseRunPe(int rank)
 {
     // init state
-    int pe = *(int *)args;
-    CmiInitState(pe);
+    CmiInitState(rank);
 
     // barrier to ensure all global structs are initialized
     CmiNodeBarrier();
@@ -49,30 +71,25 @@ void *converseRunPe(void *args)
     // call initial function and start scheduler
     Cmi_startfn(Cmi_argc, Cmi_argv);
     CsdScheduler();
-
-    return NULL;
 }
 
 void CmiStartThreads()
 {
-    pthread_t threadId[Cmi_npes];
-
-    // TODO: how to get enumerated pe nums for each thread?
-    // this would be much cleaner with std::threads
-    int threadPeNums[Cmi_npes];
-
     // allocate global arrayss
-    Cmi_queues = new ConverseQueue<void *> *[Cmi_npes];
-    CmiHandlerTable = new std::vector<CmiHandlerInfo> *[Cmi_npes];
+    Cmi_queues = new ConverseQueue<void *> *[Cmi_mynodesize];
+    CmiHandlerTable = new std::vector<CmiHandlerInfo> *[Cmi_mynodesize];
+    CmiNodeQueue = new ConverseNodeQueue<void *>();
 
-    for (int i = 0; i < Cmi_npes; i++)
+    std::vector<std::thread> threads;
+    for (int i = 0; i < Cmi_mynodesize; i++)
     {
-        threadPeNums[i] = i;
-        pthread_create(&threadId[i], NULL, converseRunPe, &threadPeNums[i]);
+        std::thread t(converseRunPe, i);
+        threads.push_back(std::move(t));
     }
-    for (int i = 0; i < Cmi_npes; i++)
+
+    for (auto &thread : threads)
     {
-        pthread_join(threadId[i], NULL);
+        thread.join();
     }
 }
 
@@ -95,10 +112,33 @@ void ConverseInit(int argc, char **argv, CmiStartFn fn, int usched, int initret)
     int i;
     for (i = 2; i <= argc; i++)
         Cmi_argv[i - 2] = argv[i];
+
+    comm_backend::init(&argc, &Cmi_argv);
+    Cmi_mynode = comm_backend::getMyNodeId();
+    Cmi_numnodes = comm_backend::getNumNodes();
+    // Need to discuss this with the team
+    if (Cmi_npes < Cmi_numnodes)
+    {
+        fprintf(stderr, "Error: Number of PEs must be greater than or equal to number of nodes\n");
+        exit(1);
+    }
+    if (Cmi_npes % Cmi_numnodes != 0)
+    {
+        fprintf(stderr, "Error: Number of PEs must be a multiple of number of nodes\n");
+        exit(1);
+    }
+    Cmi_mynodesize = Cmi_npes / Cmi_numnodes;
+    Cmi_nodestart = Cmi_mynode * Cmi_mynodesize;
+    // register am handlers
+    AmHandlerPE = comm_backend::registerAmHandler(CommRemoteHandlerPE);
+    AmHandlerNode = comm_backend::registerAmHandler(CommRemoteHandlerNode);
+
     Cmi_startfn = fn;
 
     CmiStartThreads();
     free(Cmi_argv);
+    
+    comm_backend::exit();
 }
 
 // CMI STATE
@@ -112,9 +152,9 @@ void CmiInitState(int rank)
 {
     // allocate state
     Cmi_state = new CmiState;
-    Cmi_state->pe = rank;
-    Cmi_state->rank = rank; // TODO: for now, pe is just thread index
-    Cmi_state->node = 0;    // TODO: get node
+    Cmi_state->pe = Cmi_nodestart + rank;
+    Cmi_state->rank = rank;
+    Cmi_state->node = Cmi_mynode;
     Cmi_state->stopFlag = 0;
 
     Cmi_myrank = rank;
@@ -124,8 +164,6 @@ void CmiInitState(int rank)
     // allocate global entries
     ConverseQueue<void *> *queue = new ConverseQueue<void *>();
     std::vector<CmiHandlerInfo> *handlerTable = new std::vector<CmiHandlerInfo>();
-
-    CmiNodeQueue = new ConverseNodeQueue<void *>();
 
     Cmi_queues[Cmi_myrank] = queue;
     CmiHandlerTable[Cmi_myrank] = handlerTable;
@@ -145,7 +183,7 @@ int CmiMyRank()
 
 int CmiMyPe()
 {
-    return CmiMyRank(); // TODO: fix once in multi node context
+    return CmiGetState()->pe;
 }
 
 int CmiStopFlag()
@@ -160,12 +198,22 @@ int CmiMyNode()
 
 int CmiMyNodeSize()
 {
-    return Cmi_npes; // TODO: get node size (this is not the same)
+    return Cmi_mynodesize;
 }
 
 int CmiNumPes()
 {
     return Cmi_npes;
+}
+
+int CmiNodeOf(int pe)
+{
+    return pe / Cmi_mynodesize;
+}
+
+int CmiRankOf(int pe)
+{
+    return pe % Cmi_mynodesize;
 }
 
 std::vector<CmiHandlerInfo> *CmiGetHandlerTable()
@@ -175,7 +223,8 @@ std::vector<CmiHandlerInfo> *CmiGetHandlerTable()
 
 void CmiPushPE(int destPE, int messageSize, void *msg)
 {
-    Cmi_queues[destPE]->push(msg);
+    int rank = CmiRankOf(destPE);
+    Cmi_queues[rank]->push(msg);
 }
 
 void *CmiAlloc(int size)
@@ -198,14 +247,17 @@ void CmiSyncSend(int destPE, int messageSize, void *msg)
 void CmiSyncSendAndFree(int destPE, int messageSize, void *msg)
 {
     // printf("Sending message to PE %d\n", destPE);
-    int destNode = 0; // TODO: get node from destPE?
+    CmiMessageHeader *header = static_cast<CmiMessageHeader*>(msg);
+    header->destPE = destPE;
+    header->messageSize = messageSize;
+    int destNode = CmiNodeOf(destPE);
     if (CmiMyNode() == destNode)
     {
         CmiPushPE(destPE, messageSize, msg);
     }
     else
     {
-        // TODO: handle off node message send
+        comm_backend::sendAm(destNode, msg, messageSize, CommLocalHandler, AmHandlerPE);
     }
 }
 
@@ -286,7 +338,7 @@ void CmiSyncNodeSendAndFree(unsigned int destNode, unsigned int size, void *msg)
     }
     else
     {
-        // TODO: if off node
+        comm_backend::sendAm(destNode, msg, size, CommLocalHandler, AmHandlerNode);
     }
 }
 

--- a/convcore.h
+++ b/convcore.h
@@ -2,6 +2,8 @@
 #define CONVCORE_H
 
 #include "converse.h"
+#include "converse_config.h"
+#include "comm_backend/comm_backend.h"
 #include "queue.h"
 
 typedef struct Header

--- a/convcore.h
+++ b/convcore.h
@@ -23,7 +23,7 @@ typedef struct Header
 // } CmiMessage;
 
 void CmiStartThreads(char **argv);
-void *converseRunPe(void *arg);
+void converseRunPe(int rank);
 
 // HANDLERS
 // TODO: what is CmiHandlerEx in old converse?

--- a/converse.h
+++ b/converse.h
@@ -20,6 +20,8 @@ int CmiMyNode();
 int CmiMyNodeSize();
 int CmiMyRank();
 int CmiNumPes();
+int CmiNodeOf(int pe);
+int CmiRankOf(int pe);
 int CmiStopFlag();
 
 void CmiSetHandler(void *msg, int handlerId);

--- a/converse_config.h.in
+++ b/converse_config.h.in
@@ -1,0 +1,6 @@
+#ifndef CONVERSE_CONFIG_H
+#define CONVERSE_CONFIG_H
+
+#cmakedefine RECONVERSE_ENABLE_COMM_LCI1
+
+#endif

--- a/scheduler.C
+++ b/scheduler.C
@@ -80,6 +80,8 @@ void CsdScheduler()
                     CcdRaiseCondition(CcdPROCESSOR_LONG_IDLE);
                 }
             }
+            // poll the communication layer
+            comm_backend::progress();
         }
 
         CcdCallBacks();


### PR DESCRIPTION
This PR adds a very simple comm_backend layer (comm_backend/comm_backend.h) that abstracts the communication interface needed to be implemented to support the reconverse layer. This layer is based on active messages.

It also contains a very basic LCI1 implementation of the comm_backend layer. It uses the LCI1 put dynamic primitive and completion handler to implement the active message semantics. It currently only uses one device and always copies the data on the receiver side before passing it to the convcore layer.

Currently, users need an external LCI1 installation to build the LCI1 backend. I will add a cmake autofetch feature layer.

I also fixed a fair amount of code inside the convcore layer and ping_ack example to make them work. Previously they treated `pe` and `rank` as the same. Other examples may also need to be fixed regarding their usage of `rank` and `pe`.
