### PR TITLE
Add CmiArg functions

### DIFF
--- a/conv-header.h
+++ b/conv-header.h
@@ -1,0 +1,15 @@
+#ifndef _CONV_HEADER_H
+#define _CONV_HEADER_H
+
+#include <cinttypes>
+
+using CmiInt1 = std::int8_t;
+using CmiInt2 = std::int16_t;
+using CmiInt4 = std::int32_t;
+using CmiInt8 = std::int64_t;
+using CmiUint1 = std::uint8_t;
+using CmiUint2 = std::uint16_t;
+using CmiUint4 = std::uint32_t;
+using CmiUint8 = std::uint64_t;
+
+#endif

--- a/convcore.C
+++ b/convcore.C
@@ -1,5 +1,4 @@
 //+pe <N> threads, each running a scheduler
-#include "conv-header.h"
 #include "convcore.h"
 #include "scheduler.h"
 #include "barrier.h"

--- a/convcore.C
+++ b/convcore.C
@@ -1,4 +1,5 @@
 //+pe <N> threads, each running a scheduler
+#include "conv-header.h"
 #include "convcore.h"
 #include "scheduler.h"
 #include "barrier.h"
@@ -11,6 +12,7 @@
 #include <cstring>
 #include <cstdarg>
 #include <thread>
+#include <cinttypes>
 
 // GLOBALS
 int Cmi_argc;
@@ -384,12 +386,6 @@ double CmiWallTimer()
     return getCurrentTime() - Cmi_startTime;
 }
 
-int CmiGetArgc(char **argv)
-{
-    // TODO: is this supposed to be argc after runtime params are extracted?
-    return Cmi_argc;
-}
-
 // TODO: implement
 void CmiAbort(const char *format, ...)
 {
@@ -426,4 +422,304 @@ double CmiGetIdleTime()
 void CmiSetIdleTime(double time)
 {
     idle_time = time;
+}
+
+/*****************************************************************************
+ *
+ * Command-Line Argument (CLA) parsing routines.
+ *
+ *****************************************************************************/
+
+static int usageChecked=0; /* set when argv has been searched for a usage request */
+static int printUsage=0; /* if set, print command-line usage information */
+static const char *CLAformatString="%20s %10s %s\n";
+
+/** This little list of CLA's holds the argument descriptions until it's
+   safe to print them--it's needed because the netlrts- versions don't have 
+   printf until they're pretty well started.
+ */
+typedef struct {
+	const char *arg; /* Flag name, like "-foo"*/
+	const char *param; /* Argument's parameter type, like "integer" or "none"*/
+	const char *desc; /* Human-readable description of what it does */
+} CLA;
+static int CLAlistLen=0;
+static int CLAlistMax=0;
+static CLA *CLAlist=NULL;
+
+/** Add this CLA */
+static void CmiAddCLA(const char *arg,const char *param,const char *desc) {
+	int i;
+	if (CmiMyPe()!=0) return; /*Don't bother if we're not PE 0*/
+	if (desc==NULL) return; /*It's an internal argument*/
+	if (usageChecked) { /* Printf should work now */
+		if (printUsage)
+			CmiPrintf(CLAformatString,arg,param,desc);
+	}
+	else { /* Printf doesn't work yet-- just add to the list.
+		This assumes the const char *'s are static references,
+		which is probably reasonable. */
+                CLA *temp;
+		i=CLAlistLen++;
+		if (CLAlistLen>CLAlistMax) { /*Grow the CLA list */
+			CLAlistMax=16+2*CLAlistLen;
+			temp = (CLA *)realloc(CLAlist,sizeof(CLA)*CLAlistMax);
+                        if(temp != NULL) {
+			  CLAlist=temp;
+                        } else {
+                          free(CLAlist);
+                          CmiAbort("Reallocation failed for CLAlist\n");
+                        }
+		}
+		CLAlist[i].arg=arg;
+		CLAlist[i].param=param;
+		CLAlist[i].desc=desc;
+	}
+}
+
+/** Print out the stored list of CLA's */
+static void CmiPrintCLAs(void) {
+	int i;
+	if (CmiMyPe()!=0) return; /*Don't bother if we're not PE 0*/
+	CmiPrintf("Converse Machine Command-line Parameters:\n ");
+	CmiPrintf(CLAformatString,"Option:","Parameter:","Description:");
+	for (i=0;i<CLAlistLen;i++) {
+		CLA *c=&CLAlist[i];
+		CmiPrintf(CLAformatString,c->arg,c->param,c->desc);
+	}
+}
+
+/**
+ * Determines if command-line usage information should be printed--
+ * that is, if a "-?", "-h", or "--help" flag is present.
+ * Must be called after printf is setup.
+ */
+void CmiArgInit(char **argv) {
+	int i;
+	// CmiLock(_smp_mutex);
+	for (i=0;argv[i]!=NULL;i++)
+	{
+		if (0==strcmp(argv[i],"-?") ||
+		    0==strcmp(argv[i],"-h") ||
+		    0==strcmp(argv[i],"--help")) 
+		{
+			printUsage=1;
+			/* Don't delete arg:  CmiDeleteArgs(&argv[i],1);
+			  Leave it there for user program to see... */
+			CmiPrintCLAs();
+		}
+	}
+	if (CmiMyPe()==0) { /* Throw away list of stored CLA's */
+		CLAlistLen=CLAlistMax=0;
+		free(CLAlist); CLAlist=NULL;
+	}
+	usageChecked=1;
+	// CmiUnlock(_smp_mutex);
+}
+
+/** Return 1 if we're currently printing command-line usage information. */
+int CmiArgGivingUsage(void) {
+	return (CmiMyPe()==0) && printUsage;
+}
+
+/** Identifies the module that accepts the following command-line parameters */
+void CmiArgGroup(const char *parentName,const char *groupName) {
+	if (CmiArgGivingUsage()) {
+		if (groupName==NULL) groupName=parentName; /* Start of a new group */
+		CmiPrintf("\n%s Command-line Parameters:\n",groupName);
+	}
+}
+
+/** Count the number of non-NULL arguments in list*/
+int CmiGetArgc(char **argv)
+{
+	int i=0,argc=0;
+	if (argv)
+	while (argv[i++]!=NULL)
+		argc++;
+	return argc;
+}
+
+/** Return a new, heap-allocated copy of the argv array*/
+char **CmiCopyArgs(char **argv)
+{
+	int argc=CmiGetArgc(argv);
+	char **ret=(char **)malloc(sizeof(char *)*(argc+1));
+	int i;
+	for (i=0;i<=argc;i++)
+		ret[i]=argv[i];
+	return ret;
+}
+
+/** Delete the first k argument from the given list, shifting
+all other arguments down by k spaces.
+e.g., argv=={"a","b","c","d",NULL}, k==3 modifies
+argv={"d",NULL,"c","d",NULL}
+*/
+void CmiDeleteArgs(char **argv,int k)
+{
+	int i=0;
+	while ((argv[i]=argv[i+k])!=NULL)
+		i++;
+}
+
+/** Find the given argment and string option in argv.
+If the argument is present, set the string option and
+delete both from argv.  If not present, return NULL.
+e.g., arg=="-name" returns "bob" from
+argv=={"a.out","foo","-name","bob","bar"},
+and sets argv={"a.out","foo","bar"};
+*/
+int CmiGetArgStringDesc(char **argv,const char *arg,char **optDest,const char *desc)
+{
+	int i;
+	CmiAddCLA(arg,"string",desc);
+	for (i=0;argv[i]!=NULL;i++)
+		if (0==strcmp(argv[i],arg))
+		{/*We found the argument*/
+			if (argv[i+1]==NULL) CmiAbort("Argument not complete!");
+			*optDest=argv[i+1];
+			CmiDeleteArgs(&argv[i],2);
+			return 1;
+		}
+	return 0;/*Didn't find the argument*/
+}
+int CmiGetArgString(char **argv,const char *arg,char **optDest) {
+	return CmiGetArgStringDesc(argv,arg,optDest,"");
+}
+
+/** Find the given argument and floating-point option in argv.
+Remove it and return 1; or return 0.
+*/
+int CmiGetArgDoubleDesc(char **argv,const char *arg,double *optDest,const char *desc) {
+	char *number=NULL;
+	CmiAddCLA(arg,"number",desc);
+	if (!CmiGetArgStringDesc(argv,arg,&number,NULL)) return 0;
+	if (1!=sscanf(number,"%lg",optDest)) return 0;
+	return 1;
+}
+int CmiGetArgDouble(char **argv,const char *arg,double *optDest) {
+	return CmiGetArgDoubleDesc(argv,arg,optDest,"");
+}
+
+/** Find the given argument and integer option in argv.
+If the argument is present, parse and set the numeric option,
+delete both from argv, and return 1. If not present, return 0.
+e.g., arg=="-pack" matches argv=={...,"-pack","27",...},
+argv=={...,"-pack0xf8",...}, and argv=={...,"-pack=0777",...};
+but not argv=={...,"-packsize",...}.
+*/
+int CmiGetArgIntDesc(char **argv,const char *arg,int *optDest,const char *desc)
+{
+	int i;
+	int argLen=strlen(arg);
+	CmiAddCLA(arg,"integer",desc);
+	for (i=0;argv[i]!=NULL;i++)
+		if (0==strncmp(argv[i],arg,argLen))
+		{/*We *may* have found the argument*/
+			const char *opt=NULL;
+			int nDel=0;
+			switch(argv[i][argLen]) {
+			case 0: /* like "-p","27" */
+				opt=argv[i+1]; nDel=2; break;
+			case '=': /* like "-p=27" */
+				opt=&argv[i][argLen+1]; nDel=1; break;
+			case '-':case '+':
+			case '0':case '1':case '2':case '3':case '4':
+			case '5':case '6':case '7':case '8':case '9':
+				/* like "-p27" */
+				opt=&argv[i][argLen]; nDel=1; break;
+			default:
+				continue; /*False alarm-- skip it*/
+			}
+			if (opt==NULL) {
+				fprintf(stderr, "Command-line flag '%s' expects a numerical argument, "
+				                "but none was provided\n", arg);
+				CmiAbort("Bad command-line argument\n");
+                        }
+			if (sscanf(opt,"%i",optDest)<1) {
+			/*Bad command line argument-- die*/
+				fprintf(stderr,"Cannot parse %s option '%s' "
+					"as an integer.\n",arg,opt);
+				CmiAbort("Bad command-line argument\n");
+			}
+			CmiDeleteArgs(&argv[i],nDel);
+			return 1;
+		}
+	return 0;/*Didn't find the argument-- dest is unchanged*/
+}
+int CmiGetArgInt(char **argv,const char *arg,int *optDest) {
+	return CmiGetArgIntDesc(argv,arg,optDest,"");
+}
+
+int CmiGetArgLongDesc(char **argv,const char *arg,CmiInt8 *optDest,const char *desc)
+{
+	int i;
+	int argLen=strlen(arg);
+	CmiAddCLA(arg,"integer",desc);
+	for (i=0;argv[i]!=NULL;i++)
+		if (0==strncmp(argv[i],arg,argLen))
+		{/*We *may* have found the argument*/
+			const char *opt=NULL;
+			int nDel=0;
+			switch(argv[i][argLen]) {
+			case 0: /* like "-p","27" */
+				opt=argv[i+1]; nDel=2; break;
+			case '=': /* like "-p=27" */
+				opt=&argv[i][argLen+1]; nDel=1; break;
+			case '-':case '+':
+			case '0':case '1':case '2':case '3':case '4':
+			case '5':case '6':case '7':case '8':case '9':
+				/* like "-p27" */
+				opt=&argv[i][argLen]; nDel=1; break;
+			default:
+				continue; /*False alarm-- skip it*/
+			}
+			if (opt==NULL) {
+				fprintf(stderr, "Command-line flag '%s' expects a numerical argument, "
+				                "but none was provided\n", arg);
+				CmiAbort("Bad command-line argument\n");
+                        }
+			if (sscanf(opt,"%" SCNd64,optDest)<1) {
+			/*Bad command line argument-- die*/
+				fprintf(stderr,"Cannot parse %s option '%s' "
+					"as a long integer.\n",arg,opt);
+				CmiAbort("Bad command-line argument\n");
+			}
+			CmiDeleteArgs(&argv[i],nDel);
+			return 1;
+		}
+	return 0;/*Didn't find the argument-- dest is unchanged*/
+}
+int CmiGetArgLong(char **argv,const char *arg,CmiInt8 *optDest) {
+	return CmiGetArgLongDesc(argv,arg,optDest,"");
+}
+
+/** Find the given argument in argv.  If present, delete
+it and return 1; if not present, return 0.
+e.g., arg=="-foo" matches argv=={...,"-foo",...} but not
+argv={...,"-foobar",...}.
+*/
+int CmiGetArgFlagDesc(char **argv,const char *arg,const char *desc)
+{
+	int i;
+	CmiAddCLA(arg,"",desc);
+	for (i=0;argv[i]!=NULL;i++)
+		if (0==strcmp(argv[i],arg))
+		{/*We found the argument*/
+			CmiDeleteArgs(&argv[i],1);
+			return 1;
+		}
+	return 0;/*Didn't find the argument*/
+}
+int CmiGetArgFlag(char **argv,const char *arg) {
+	return CmiGetArgFlagDesc(argv,arg,"");
+}
+
+void CmiDeprecateArgInt(char **argv,const char *arg,const char *desc,const char *warning)
+{
+  int dummy = 0, found = CmiGetArgIntDesc(argv, arg, &dummy, desc);
+
+  if (found)
+    CmiPrintf("%s\n", warning);
 }

--- a/converse.h
+++ b/converse.h
@@ -1,6 +1,7 @@
 #ifndef CONVERSE_H
 #define CONVERSE_H
 
+#include "conv-header.h"
 #include "CpvMacros.h" // for backward compatibility
 
 typedef struct Header
@@ -103,6 +104,24 @@ void CcdCancelCallOnCondition(int condnum, int idx);
 void CcdCancelCallOnConditionKeep(int condnum, int idx);
 void CcdRaiseCondition(int condnum);
 void CcdCallBacks(void);
+
+/* Command-Line-Argument handling */
+void CmiArgGroup(const char *parentName,const char *groupName);
+int CmiGetArgInt(char **argv,const char *arg,int *optDest);
+int CmiGetArgIntDesc(char **argv,const char *arg,int *optDest,const char *desc);
+int CmiGetArgLong(char **argv,const char *arg,CmiInt8 *optDest);
+int CmiGetArgLongDesc(char **argv,const char *arg,CmiInt8 *optDest,const char *desc);
+int CmiGetArgDouble(char **argv,const char *arg,double *optDest);
+int CmiGetArgDoubleDesc(char **argv,const char *arg,double *optDest,const char *desc);
+int CmiGetArgString(char **argv,const char *arg,char **optDest);
+int CmiGetArgStringDesc(char **argv,const char *arg,char **optDest,const char *desc);
+int CmiGetArgFlag(char **argv,const char *arg);
+int CmiGetArgFlagDesc(char **argv,const char *arg,const char *desc);
+void CmiDeleteArgs(char **argv,int k);
+int CmiGetArgc(char **argv);
+char **CmiCopyArgs(char **argv);
+int CmiArgGivingUsage(void);
+void CmiDeprecateArgInt(char **argv,const char *arg,const char *desc,const char *warning);
 
 //error checking
 #define CmiAssert(expr) ((void)0)


### PR DESCRIPTION
This PR adds the declaration/implementation for arg handling. Using these methods to actually handle the args will be done in a future PR.

I have also included a `conv-header.h` that defines `CmiInt` and CmiUint` types used throughout Converse.