### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,22 @@ $ cd build
 $ cmake -DRECONVERSE_TRY_ENABLE_COMM_LCI1=ON -DRECONVERSE_AUTOFETCH_LCI1=ON -DLCI_SERVER=ofi -DLCT_PMI_BACKEND_ENABLE_MPI=ON ..
 $ make
 ```
-Note: if you installed `libfabric` or `mpi` in a non-standard location, you may need to set `CMAKE_PREFIX_PATH` to the correct path.
+
+**Note:** if you installed `libfabric` or `mpi` in a non-standard location, CMake *may* complain it cannot find OFI/MPI, in which case you need to let CMake find them by
+```
+export OFI_ROOT=<path_to_libfabric>
+export MPI_ROOT=<path_to_mpi>
+```
 
 #### Run reconverse
 ```
 $ cd build/examples/pingpong
 $ mpirun -n 2 ./reconverse_ping_ack +pe 4
+```
+
+**Note:** if you installed `libfabric` or `mpi` in a non-standard location, the linker *may* complain it cannot find the libfabric/mpi shared library, in which case you need to let the linker find them by
+```
+export LD_LIBRARY_PATH=<path_to_libfabric_lib>:<path_to_mpi_lib>:${LD_LIBRARY_PATH}
 ```
 
 ### Build and run Reconverse on NCSA Delta


### PR DESCRIPTION
Give detailed instructions for the case when libfabric/mpi are installed in a non-standard location.