### PR TITLE
Implement CmiEnforce

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -106,6 +106,18 @@ void CmiAbort(const char *format, ...);
 void CmiInitCPUTopology(char **argv);
 void CmiInitCPUAffinity(char **argv);
 
+void __CmiEnforceMsgHelper(const char* expr, const char* fileName,
+			   int lineNum, const char* msg, ...);
+
+#define CmiEnforce(condition)                            \
+  do                                                     \
+  {                                                      \
+    if (!(condition))                                    \
+    {                                                    \
+      __CmiEnforceMsgHelper(#condition, __FILE__, __LINE__, ""); \
+    }                                                    \
+  } while (0)
+
 double getCurrentTime(void);
 double CmiWallTimer(void);
 

--- a/src/convcore.C
+++ b/src/convcore.C
@@ -425,6 +425,7 @@ void CmiAbort(const char *format, ...) {
   vsnprintf(newmsg, sizeof(newmsg), format, args);
   va_end(args);
   CmiAbortHelper("Called CmiAbort", newmsg, NULL, 1, 0);
+  abort();
 }
 
 

--- a/src/convcore.C
+++ b/src/convcore.C
@@ -412,11 +412,27 @@ double CmiWallTimer()
     return getCurrentTime() - Cmi_startTime;
 }
 
-// TODO: implement
-void CmiAbort(const char *format, ...)
+void CmiAbortHelper(const char *source, const char *message, const char *suggestion,
+                    int tellDebugger, int framesToSkip) {
+    CmiPrintf("------- Processor %d Exiting: %s ------\n"
+             "Reason: %s\n", CmiMyPe(), source, message);
+}
+
+void CmiAbort(const char *format, ...) {
+  char newmsg[256];
+  va_list args;
+  va_start(args, format);
+  vsnprintf(newmsg, sizeof(newmsg), format, args);
+  va_end(args);
+  CmiAbortHelper("Called CmiAbort", newmsg, NULL, 1, 0);
+}
+
+
+void __CmiEnforceMsgHelper(const char* expr, const char* fileName,
+			   int lineNum, const char* msg, ...) 
 {
-    printf("CMI ABORT\n");
-    abort();
+    CmiAbort("[%d] Assertion \"%s\" failed in file %s line %d.\n", CmiMyPe(), expr,
+             fileName, lineNum);
 }
 
 // TODO: implememt


### PR DESCRIPTION
Adds an implementation of `CmiEnforce`.
Updates `CmiAbort` output format to match Charm