### PR TITLE
handle dangling messages

### DIFF
--- a/src/comm_backend/lci2/comm_backend_lci2.cpp
+++ b/src/comm_backend/lci2/comm_backend_lci2.cpp
@@ -29,10 +29,9 @@ void CommBackendLCI2::init(int *argc, char ***argv) {
 }
 
 void CommBackendLCI2::exit() {
-  lci::barrier();
+  lci::g_runtime_fina();
   lci::free_comp(&m_local_comp);
   lci::free_comp(&m_remote_comp);
-  lci::g_runtime_fina();
 }
 
 int CommBackendLCI2::getMyNodeId() { return lci::get_rank_me(); }

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -119,6 +119,7 @@ void CmiStartThreads() {
 
   // make sure all PEs are done before we free the queues.
   comm_backend::barrier();
+  comm_backend::exit();
   delete[] Cmi_queues;
   delete CmiNodeQueue;
   delete[] CmiHandlerTable;
@@ -176,8 +177,6 @@ void ConverseInit(int argc, char **argv, CmiStartFn fn, int usched,
 
   CmiStartThreads();
   free(Cmi_argv);
-
-  comm_backend::exit();
 }
 
 // CMI STATE


### PR DESCRIPTION
Reduce the likelihood of LCI backend panicking due to the presence of dangling messages following scheduler termination.