### PR TITLE
fix CpvCExtern

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -64,11 +64,7 @@ typedef __uint128_t CmiUInt16;
 #define CpvExtern(t, v) extern t *CMK_TAG(Cpv_, v)
 #define CpvInitialized(v) (0 != CMK_TAG(Cpv_, v))
 
-#define CMK_THREADLOCAL __thread
-#define CpvCExtern(t, v)                                                       \
-  extern "C" CMK_THREADLOCAL t *CMK_TAG(Cpv_, v);                              \
-  extern "C" int CMK_TAG(Cpv_inited_, v);                                      \
-  extern "C" t **CMK_TAG(Cpv_addr_, v)
+#define CpvCExtern(t,v)    extern "C" t* CMK_TAG(Cpv_,v)
 
 #define CsvDeclare(t, v) t v
 #define CsvStaticDeclare(t, v) static t v

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -37,6 +37,7 @@ std::atomic<int> _cleanUp = 0;
 void *memory_stack_top;
 CmiNodeLock _smp_mutex;
 CpvDeclare(std::vector<NcpyOperationInfo *>, newZCPupGets);
+CpvCExtern(int,interopExitFlag);
 CpvDeclare(int,interopExitFlag);
 std::atomic<int> ckExitComplete {0};
 int quietMode;


### PR DESCRIPTION
There were issues in the CpvCExtern definition (I accidentally included the TLS version) so I fixed it.