### PR TITLE
fix pingpong_multipairs: reset sumTime for each message size

### DIFF
--- a/examples/orig-converse/pingpong/pingpong_multipairs.cpp
+++ b/examples/orig-converse/pingpong/pingpong_multipairs.cpp
@@ -57,6 +57,7 @@ void reduceHandlerFunc(char *msg) {
     size_t msgSizeDiff = CpvAccess(msgSize) - CmiMsgHeaderSizeBytes;
     CmiPrintf("%zu\t\t  %.2lf   %.2f\n", msgSizeDiff, us_time,
               msgSizeDiff / us_time);
+    CpvAccess(sumTime) = 0;
     CpvAccess(recvNum) = 0;
 
     if (CpvAccess(msgSize) < maxMsgSize) {


### PR DESCRIPTION
Otherwise, the `sumTime` will keep accumulating, and the latency for the following message size will not be accurate.