### PR TITLE
Reference counting + SMP fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ set(RECONVERSE_AUTOFETCH_LCI2_TAG
     CACHE STRING "The tag to fetch for LCIv2") # master branch as of 2025-08-19
 
 option(SPANTREE "whether to enable spanning tree collectives" OFF) #should turn this on once charm issues fixed
+
+# Reconverse uses SMP always, but turn on this option for backwards compatibility (see pingpong_multipairs for example)
 option(CMK_SMP "whether to enable SMP support" ON)
 
 option(RECONVERSE_ATOMIC_QUEUE "whether to use atomic queue" ON)

--- a/include/converse.h
+++ b/include/converse.h
@@ -7,7 +7,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <pthread.h>
-#include <atomic>
 
 using CmiInt1 = std::int8_t;
 using CmiInt2 = std::int16_t;
@@ -144,7 +143,7 @@ struct alignas(ALIGN_BYTES) CmiChunkHeader {
   int size;
 
 private:
-#ifdef CMK_SMP
+#if CMK_SMP
   std::atomic<int> ref;
 #else
   int ref;
@@ -153,17 +152,15 @@ private:
 public:
   CmiChunkHeader() = default;
   CmiChunkHeader(const CmiChunkHeader &x) : size{x.size}, ref{x.getRef()} {}
-#ifdef CMK_SMP
+#if CMK_SMP
   int getRef() const { return ref.load(std::memory_order_acquire); }
   void setRef(int r) { return ref.store(r, std::memory_order_release); }
   int incRef() { return ref.fetch_add(1, std::memory_order_release); }
-  int decRef() { 
-    return ref.fetch_sub(1, std::memory_order_release);
-  }
+  int decRef() { return ref.fetch_sub(1, std::memory_order_release); }
 #else
   int getRef() const { return ref; }
   void setRef(int r) { ref = r; }
-  int incRef() {    return ref++; }
+  int incRef() { return ref++; }
   int decRef() { return ref--; }
 #endif
 };

--- a/include/converse.h
+++ b/include/converse.h
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <pthread.h>
+#include <atomic>
 
 using CmiInt1 = std::int8_t;
 using CmiInt2 = std::int16_t;

--- a/include/converse.h
+++ b/include/converse.h
@@ -113,7 +113,9 @@ typedef struct Header {
 
 typedef CmiMessageHeader CmiMsgHeaderBasic;
 
-#define CMK_NODE_QUEUE_AVAILABLE CMK_SMP
+// #define CMK_NODE_QUEUE_AVAILABLE CMK_SMP
+#define CMK_NODE_QUEUE_AVAILABLE 1 // we assume CMK_SMP
+
 
 typedef struct {
   int parent;
@@ -143,26 +145,19 @@ struct alignas(ALIGN_BYTES) CmiChunkHeader {
   int size;
 
 private:
-#if CMK_SMP
-  std::atomic<int> ref;
-#else
-  int ref;
-#endif
+  std::atomic<int> ref; // only supports smp, would just be int otherwise
+
 
 public:
   CmiChunkHeader() = default;
   CmiChunkHeader(const CmiChunkHeader &x) : size{x.size}, ref{x.getRef()} {}
-#if CMK_SMP
+
+  // reference counting (assumes SMP. otherwise could just use basic int operations)
   int getRef() const { return ref.load(std::memory_order_acquire); }
   void setRef(int r) { return ref.store(r, std::memory_order_release); }
   int incRef() { return ref.fetch_add(1, std::memory_order_release); }
-  int decRef() { return ref.fetch_sub(1, std::memory_order_release); }
-#else
-  int getRef() const { return ref; }
-  void setRef(int r) { ref = r; }
-  int incRef() { return ref++; }
-  int decRef() { return ref--; }
-#endif
+  int decRef() { return ref.fetch_sub(1, std::memory_order_release);}
+
 };
 
 // threads library

--- a/include/converse.h
+++ b/include/converse.h
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <pthread.h>
+#include <atomic>
 
 using CmiInt1 = std::int8_t;
 using CmiInt2 = std::int16_t;
@@ -143,7 +144,7 @@ struct alignas(ALIGN_BYTES) CmiChunkHeader {
   int size;
 
 private:
-#if CMK_SMP
+#ifdef CMK_SMP
   std::atomic<int> ref;
 #else
   int ref;
@@ -152,15 +153,17 @@ private:
 public:
   CmiChunkHeader() = default;
   CmiChunkHeader(const CmiChunkHeader &x) : size{x.size}, ref{x.getRef()} {}
-#if CMK_SMP
+#ifdef CMK_SMP
   int getRef() const { return ref.load(std::memory_order_acquire); }
   void setRef(int r) { return ref.store(r, std::memory_order_release); }
   int incRef() { return ref.fetch_add(1, std::memory_order_release); }
-  int decRef() { return ref.fetch_sub(1, std::memory_order_release); }
+  int decRef() { 
+    return ref.fetch_sub(1, std::memory_order_release);
+  }
 #else
   int getRef() const { return ref; }
   void setRef(int r) { ref = r; }
-  int incRef() { return ref++; }
+  int incRef() {    return ref++; }
   int decRef() { return ref--; }
 #endif
 };

--- a/src/comm_backend/comm_backend_internal.h
+++ b/src/comm_backend/comm_backend_internal.h
@@ -4,8 +4,9 @@
 #include <cstdio>
 #include <vector>
 
-#include "comm_backend/comm_backend.h"
 #include "converse_config.h"
+#include "comm_backend/comm_backend.h"
+
 
 namespace comm_backend {
 

--- a/src/comm_backend/comm_backend_internal.h
+++ b/src/comm_backend/comm_backend_internal.h
@@ -4,9 +4,8 @@
 #include <cstdio>
 #include <vector>
 
-#include "converse_config.h"
 #include "comm_backend/comm_backend.h"
-
+#include "converse_config.h"
 
 namespace comm_backend {
 

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -337,7 +337,7 @@ void *CmiAlloc(int size) {
 
   char* ptr = blk + sizeof(CmiChunkHeader);
   REFFIELDSET(ptr, 1);
-  SIZEFIELD(ptr) = size;
+  SIZEFIELD(ptr) = size; // TODO: where is this used? just stole from old converse
 
   return (void*)(ptr);
 }
@@ -345,6 +345,7 @@ void *CmiAlloc(int size) {
 
 // header ref count methods
 
+// TODO: what is this for? still needed? copied from old converse.
 static void *CmiAllocFindEnclosing(void *blk) {
   int refCount = REFFIELD(blk);
   while (refCount < 0) {

--- a/src/converse_internal.h
+++ b/src/converse_internal.h
@@ -5,8 +5,8 @@
 
 #include <cstring>
 
-#include "converse_config.h"
 #include "converse.h"
+#include "converse_config.h"
 #include "queue.h"
 
 #include "comm_backend/comm_backend.h"

--- a/src/converse_internal.h
+++ b/src/converse_internal.h
@@ -4,6 +4,7 @@
 #define CONVCORE_H
 
 #include <cstring>
+#include "converse.h"
 
 #include "converse.h"
 #include "converse_config.h"
@@ -116,9 +117,10 @@ typedef struct {
 
 typedef struct {
   // in non-SMP, node reduction is equivalent to PE reduction
-#ifdef CMK_SMP
+  // Reconverse assumes SMP, use a node lock
+
   CmiNodeLock lock;
-#endif
+
   CmiReduction *red;
 } CmiNodeReduction;
 
@@ -127,11 +129,9 @@ CpvStaticDeclare(CmiReduction **,
                  _reduction_info); // an array of pointers to reduction structs
 CpvStaticDeclare(CmiReductionID, _reduce_seqID_global);
 
-#ifdef CMK_SMP
+// atomics used here to support SMP
 using CmiNodeReductionID = std::atomic<CmiReductionID>;
-#else
-using CmiNodeReductionID = CmiReductionID;
-#endif
+
 CsvStaticDeclare(CmiNodeReductionID, _node_reduction_counter);
 CsvStaticDeclare(
     CmiNodeReduction *,

--- a/src/converse_internal.h
+++ b/src/converse_internal.h
@@ -5,8 +5,8 @@
 
 #include <cstring>
 
-#include "converse.h"
 #include "converse_config.h"
+#include "converse.h"
 #include "queue.h"
 
 #include "comm_backend/comm_backend.h"


### PR DESCRIPTION
This PR:
- adds reference counting to CmiAlloc and CmiFree
- removes CMK_SMP usage in Reconverse: we assume SMP always
- changes prompted by issues in Charm++ TreeLB strategies

Related TODO:
- [x] check if this fixes the HPCCG (?) double free issue
- [ ] write a [nokeep] benchmark 