### PR TITLE
Affinity fixes

### DIFF
--- a/src/conv-topology.h
+++ b/src/conv-topology.h
@@ -1,4 +1,5 @@
 #include "converse.h"
+#include "hwloc.h"
 #include <cstring>
 
 typedef struct {/*IPv4 IP address*/

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -105,6 +105,7 @@ void converseRunPe(int rank) {
   // init things like cld module, ccs, etc
   CldModuleInit(CmiMyArgv);
 #ifdef RECONVERSE_ENABLE_CPU_AFFINITY
+  CmiInitCPUAffinity(CmiMyArgv);
   CmiSetCPUAffinity(rank);
 #endif
 

--- a/src/cpuaffinity.cpp
+++ b/src/cpuaffinity.cpp
@@ -190,12 +190,15 @@ static int set_default_affinity(void){
 }
 
 void CmiInitCPUAffinity(char **argv) {
+    #if defined(CPU_OR)
     CmiAssignOnce(&cpuPhyNodeAffinityRecvHandlerIdx, CmiRegisterHandler((CmiHandler)cpuPhyNodeAffinityRecvHandler));
     set_default_affinity();
+    #endif
 }
 
 // Uses PU indices assigned by the OS
 int CmiSetCPUAffinity(int mycore) {
+  #if defined(CPU_OR)
   int core = mycore;
   if (core < 0) {
     printf("Error with core number");
@@ -224,6 +227,9 @@ int CmiSetCPUAffinity(int mycore) {
            CmiMyPe(), mycore);
 
   return result;
+  #else
+  return -1;
+  #endif
 }
 
 void CmiCheckAffinity(void)


### PR DESCRIPTION
This implements a default mapping for processes and threads to PUs. No custom mapping supported yet, but this fixes the CmiCheckAffinity error on multiprocess runs on Linux and the "function not implemented" error on Macs.