### PR TITLE
add charm config file

### DIFF
--- a/include/charm-config.h
+++ b/include/charm-config.h
@@ -1,0 +1,12 @@
+/**
+ * Set up variables that Reconverse doesn't need
+ * but Charm++ does, but only if they are not
+ * architecture-specific.
+ */
+
+#ifndef RECONVERSE_INCLUDE_CHARM_CONFIG_H
+#define RECONVERSE_INCLUDE_CHARM_CONFIG_H
+
+#define CMK_LBDB_ON 1
+
+#endif


### PR DESCRIPTION
Used for variables needed by Charm++ but not reconverse, but are also not arch-specific. It just has CMK_LBDB_ON for now but we can add more later. Once merged, I will change charm++ to include this file.