### PR TITLE
Fix behavior when assert fails

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -612,7 +612,7 @@ int CmiTryLock(CmiNodeLock lock);
     if (!(expr)) {                                                             \
       fprintf(stderr, "Assertion %s failed: file %s, line %d\n", #expr,        \
               __FILE__, __LINE__);                                             \
-      CmiExit(0);                                                              \
+      CmiAbort("Failed assert");                                                              \
     }                                                                          \
   } while (0)
 
@@ -621,7 +621,7 @@ int CmiTryLock(CmiNodeLock lock);
     if (!(expr)) {                                                             \
       fprintf(stderr, __VA_ARGS__);                                            \
       fprintf(stderr, "\n");                                                   \
-      CmiExit(0);                                                              \
+      CmiAbort("Failed assert");                                                              \
     }                                                                          \
   } while (0)
 #endif


### PR DESCRIPTION
This fixes issue #100. I looked and CmiAbort isn't supposed to turn off the scheduler, only exits are. It turns out we have been exiting, not aborting, when asserts fail, so this fixes it.