### PR TITLE
Change README to specify how to compile reconverse with compiler optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ option(CMK_SMP "whether to enable SMP support" ON)
 option(CMK_CPV_IS_SMP "whether to enable SMP support for cpvs" ON)
 
 option(RECONVERSE_ATOMIC_QUEUE "whether to use atomic queue" ON)
-option(RECONVERSE_OPTIMIZED "whether to compile with optimizations" ON)
 
 set(RECONVERSE_TEST_LAUNCHER
     "mpirun"
@@ -128,13 +127,6 @@ if(NOT RECONVERSE_ROOT_PROJECT)
   # This project is being fetched as a subproject by another CMake project.
   # Define an alias to mimic find_package behavior and ensure consistent usage.
   add_library(reconverse::reconverse ALIAS reconverse)
-endif()
-
-if(RECONVERSE_OPTIMIZED)
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
-  message(STATUS "Compiling with optimizations")
-else()
-  message(STATUS "Compiling without optimizations")
 endif()
 
 # ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(CMK_SMP "whether to enable SMP support" ON)
 option(CMK_CPV_IS_SMP "whether to enable SMP support for cpvs" ON)
 
 option(RECONVERSE_ATOMIC_QUEUE "whether to use atomic queue" ON)
+option(RECONVERSE_OPTIMIZED "whether to compile with optimizations" ON)
 
 set(RECONVERSE_TEST_LAUNCHER
     "mpirun"
@@ -127,6 +128,13 @@ if(NOT RECONVERSE_ROOT_PROJECT)
   # This project is being fetched as a subproject by another CMake project.
   # Define an alias to mimic find_package behavior and ensure consistent usage.
   add_library(reconverse::reconverse ALIAS reconverse)
+endif()
+
+if(RECONVERSE_OPTIMIZED)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+  message(STATUS "Compiling with optimizations")
+else()
+  message(STATUS "Compiling without optimizations")
 endif()
 
 # ##############################################################################

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ make
 
 ## Runtime options
 - -DRECONVERSE_ENABLE_CPU_AFFINITY (ON by default if hwloc is found): Enable setting CPU affinity with HWLOC (must have HWLOC installed)
+- -DCMAKE_BUILD_TYPE (not set by default): Set the build type to change which flags are passed to the compiler, e.g. use `Release` to compile with `-O3` or `Debug` to compile with `-g`
 
 ## LCI
 


### PR DESCRIPTION
We need this to more easily run performance tests between old converse and reconverse.