### PR TITLE
Fixes CthAddListener segfault on Linux due to missing initialization

### DIFF
--- a/src/threads.cpp
+++ b/src/threads.cpp
@@ -162,6 +162,8 @@ static void CthThreadInit(CthThread t) {
   th->tid.id[1] = std::atomic_fetch_add(&serialno, 1);
   th->tid.id[2] = 0;
 
+  th->listener = NULL;
+
   th->magic = THD_MAGIC_NUM;
 }
 


### PR DESCRIPTION
Another problem discovered via the barnes-hut mini app. 

When the listener is not initialized to `NULL`, the first call to `CthAddListener` will enter the second conditional block, attempting to traverse the chain of listeners, and segfault. For me, this only appeared on Linux (Delta), probably due to different initialization defaults. 

The fix is what was originally done in Converse. I'm guessing this was just due to someone not copying the implementation fully.