### PR TITLE
increase default size of converse nodequeue

### DIFF
--- a/src/queue.h
+++ b/src/queue.h
@@ -47,7 +47,7 @@ public:
 template<typename MessageType>
 class AtomicAccessControl {
     // what default size?
-    moodycamel::ConcurrentQueue<MessageType> q{256};
+    moodycamel::ConcurrentQueue<MessageType> q{8192};
 
     public:
     void push(MessageType message) {


### PR DESCRIPTION
helpful for programs (like tramlib) that have a lot of expedited node messages