### PR TITLE
add CmiExtHeaderSizeBytes

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -133,6 +133,7 @@ extern CmiSpanningTreeInfo *_topoTree;
 typedef CMK_MULTICAST_GROUP_TYPE CmiGroup;
 
 #define CmiMsgHeaderSizeBytes sizeof(CmiMessageHeader)
+#define CmiExtHeaderSizeBytes CmiMsgHeaderSizeBytes
 #define CmiReservedHeaderSize CmiMsgHeaderSizeBytes
 
 typedef void (*CmiStartFn)(int argc, char **argv);


### PR DESCRIPTION
There are some libraries (like the master-slave library that shows up in the changa build) that use this header. In reconverse, we have just CmiMessageHeader, so we set CmiExtHeaderSizeBytes=CmiMsgHeaderSizeBytes