### PR TITLE
Fix behavior when no PE arguments are passed

### DIFF
--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -222,6 +222,8 @@ void ConverseInit(int argc, char **argv, CmiStartFn fn, int usched,
 
   if (plusPeSet)
     Cmi_mynodesize = Cmi_npes / Cmi_numnodes;
+  if (!plusPeSet && !plusPSet)
+    Cmi_mynodesize = 1;
   Cmi_nodestart = Cmi_mynode * Cmi_mynodesize;
   // register am handlers
   g_amHandler = comm_backend::registerAmHandler(CommRemoteHandler);


### PR DESCRIPTION
When running a Charm program, if you pass in no arguments and you run the program standalone, the program is supposed to run with 1 process and 1 PE. However, on reconverse, the program exits before running because the current logic doesn't set Cmi_mynodesize correctly in this case. This logic changes this.