### PR TITLE
fix data race during initialization

### DIFF
--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -123,7 +123,11 @@ void converseRunPe(int rank) {
   collectiveInit();
   // Cmi_multicastHandler = CmiRegisterHandler(CmiMulticastHandler);
 
-  // barrier to ensure all global structs are initialized
+  // A global barrier to ensure all global structs are initialized
+  CmiNodeBarrier();
+  if (rank == 0) {
+    comm_backend::barrier();
+  }
   CmiNodeBarrier();
 
   CthInit(NULL);


### PR DESCRIPTION
This PR introduces a global barrier across all PEs inside converseRunPe to ensure that no PE begins sending messages before all PEs have finished setting up their states.

fix #135 