### PR TITLE
Make progress call configurable

### DIFF
--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -54,6 +54,8 @@ int _Cmi_numpes_global;
 int _Cmi_mynode_global;
 int _Cmi_numnodes_global;
 int Cmi_nodestartGlobal;
+int backend_poll_freq;
+int backend_poll_thread;
 
 void (*CmiTraceFn)(char **argv) = nullptr;
 
@@ -235,6 +237,13 @@ void ConverseInit(int argc, char **argv, CmiStartFn fn, int usched,
 #ifdef RECONVERSE_ENABLE_CPU_AFFINITY
   CmiInitHwlocTopology();
 #endif
+
+  backend_poll_freq = 1; // default to poll every iteration
+  CmiGetArgInt(argv, "+backend_poll_freq", &backend_poll_freq);
+  if (backend_poll_freq < 1) backend_poll_freq = 1;
+  backend_poll_thread = 1; // default to every thread
+  CmiGetArgInt(argv, "+backend_poll_thread", &backend_poll_thread);
+  if (backend_poll_thread < 1) backend_poll_thread = 1;
 
   Cmi_argv = argv;
   Cmi_startfn = fn;

--- a/src/converse_internal.h
+++ b/src/converse_internal.h
@@ -58,6 +58,10 @@ typedef struct State {
   int stopFlag = 0;
 } CmiState;
 
+extern int backend_poll_freq; // poll every backend_poll_freq iterations of the
+                             // scheduler loop
+extern int backend_poll_thread; // every backend_poll_thread threads will call progress
+
 // state relevant functionality
 CmiState *CmiGetState(void);
 void CmiInitState(int pe);

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -67,7 +67,7 @@ void CsdScheduler() {
         }
       }
     }
-    if((CmiMyRank() % 4 == 0) && (loop_counter++ == 3))
+    if((CmiMyRank() % backend_poll_thread == 0) && (loop_counter++ == (backend_poll_freq - 1)))
     {
       loop_counter = 0;
       comm_backend::progress();


### PR DESCRIPTION
This might seem quite arbitrary, but I ran experiments on pingpong, histo, and sssp, and what I found is that if I change the comm backend to be polled by every 4th comm thread in a process (assuming there are enough comm threads), and I poll once every 4 scheduler loops, I get the best, or near the best, performance for all the benchmarks I used (the exact optimal is application-dependent but this was broadly the best). 

I decided to make the progress call configurable to change how frequently polling happens, and which thread polls in a process. There are 2 optional runtime arguments:

`+backend_poll_thread` (default 1), this means every x threads calls `comm_backend::progress()`. So if it's set to 4 and I have 16 PEs in a process, every 4th PE will call progress, and none of the others will

`+backend_poll_freq` (default 1), this means progress is called every x loops. If this is set to 4, every thread that is set to call progress will call it once every 4th scheduler loop.

I hope others can experiment with this. Does it make sense for this to be configurable?