### PR TITLE
Finish NAMD build with memory flag

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -366,6 +366,14 @@ void CmiMemoryMarkBlock(void *blk);
 extern void
     *memory_stack_top; // TODO: replace this with actual memory implementation
 
+#define CMI_MEMORY_IS_ISOMALLOC   (1<<1)
+#define CMI_MEMORY_IS_PARANOID    (1<<2)
+#define CMI_MEMORY_IS_GNU         (1<<3)
+#define CMI_MEMORY_IS_GNUOLD      (1<<4)
+#define CMI_MEMORY_IS_OS          (1<<5)
+#define CMI_MEMORY_IS_CHARMDEBUG  (1<<6)
+int CmiMemoryIs(int flag); /* return state of this flag */
+
 // state getters
 int CmiMyPe();
 int CmiMyNode();
@@ -593,6 +601,7 @@ double CrnDrandRange(double, double);
 #define CcdUSERMAX 127
 
 // convcond functions
+#define CCD_COND_FN_EXISTS 1 //needed for namd WorkDistrib.C
 typedef void (*CcdCondFn)(void *userParam);
 typedef void (*CcdVoidFn)(void *userParam, double curWallTime);
 void CcdModuleInit();

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -47,6 +47,7 @@ int quietMode;
 int quietModeRequested;
 int userDrivenMode;
 int _replaySystem = 0;
+static int CmiMemoryIs_flag=0;
 
 CmiNodeLock CmiMemLock_lock;
 CpvDeclare(int, isHelperOn);
@@ -295,6 +296,7 @@ void CmiInitState(int rank) {
                 newZCPupGets); // Check if this is necessary
   CpvInitialize(int, interopExitFlag);
   CpvAccess(interopExitFlag) = 0;
+  if(rank == 0) CmiMemoryIs_flag |= CMI_MEMORY_IS_OS;
   CmiOnesidedDirectInit();
   CcdModuleInit();
   CpvInitialize(Queue, CsdSchedQueue);
@@ -1163,6 +1165,11 @@ void StartInteropScheduler() {
 }
 
 void StopInteropScheduler() { CpvAccess(interopExitFlag) = 1; }
+
+int CmiMemoryIs(int flag)
+{
+	return (CmiMemoryIs_flag&flag)==flag;
+}
 
 static char *CopyMsg(char *msg, int len) {
   char *copy = (char *)CmiAlloc(len);


### PR DESCRIPTION
The NAMD build completes with these 2 additions

* CmiMemoryIs_flag and associated macros, which NAMD uses which memory allocation functions to call (malloc or Cmi implementation)
* CCD_COND_FN_EXISTS, a macro that's always set to 1, neither Charm or converse use this internally, just NAMD. NAMD should get rid of this at some point