### PR TITLE
fix bug in list sending

### DIFF
--- a/src/collectives.cpp
+++ b/src/collectives.cpp
@@ -610,8 +610,9 @@ void CmiSyncListSendFn(int npes, const int *pes, int len, char *msg) {
 
 void CmiSyncListSendAndFree(int npes, const int *pes, int len, void *msg) {
   for (int i = 0; i < npes; i++) {
-    CmiSyncSendAndFree(pes[i], len, msg);
+    CmiSyncSend(pes[i], len, msg);
   }
+  CmiFree(msg);
 }
 
 void CmiFreeListSendFn(int npes, const int *pes, int len, char *msg) {


### PR DESCRIPTION
This was always freeing the message after the first send in a list. This correct this. Bug first appeared in namd, in WorkDistrib::savePatchMap(PatchMapMsg *msg), used to resend forward messages before processing