### PR TITLE
fix cmakedefine for spantree

### DIFF
--- a/src/collectives.cpp
+++ b/src/collectives.cpp
@@ -33,8 +33,7 @@ void CmiSyncBroadcast(int size, void *msg) {
     CmiMessageHeader *header = static_cast<CmiMessageHeader *>(msg);
     header->messageSize = size;
   
-  #ifdef SPANTREE
-  #if SPANTREE ON
+  #if SPANTREE
     DEBUGF("[%d] Spanning tree option\n", CmiMyPe());
     CmiSetBcastSource(msg, pe); // used to skip the source
     header->swapHandlerId = header->handlerId;
@@ -43,14 +42,6 @@ void CmiSyncBroadcast(int size, void *msg) {
   #else
     for (int i = pe + 1; i < CmiNumPes(); i++)
         CmiSyncSend(i, size, msg);
-  
-    for (int i = 0; i < pe; i++)
-      CmiSyncSend(i, size, msg);
-  #endif
-  #else
-  
-    for (int i = pe + 1; i < CmiNumPes(); i++)
-      CmiSyncSend(i, size, msg);
   
     for (int i = 0; i < pe; i++)
       CmiSyncSend(i, size, msg);
@@ -67,17 +58,12 @@ void CmiSyncBroadcast(int size, void *msg) {
     CmiMessageHeader *header = static_cast<CmiMessageHeader *>(msg);
     header->messageSize = size;
   
-  #ifdef SPANTREE
-  #if SPANTREE ON
+  #if SPANTREE
     CmiSetBcastSource(msg, -1); // don't skip the source
     header->swapHandlerId = header->handlerId;
   
     header->handlerId = Cmi_bcastHandler;
     CmiSyncSend(0, size, msg);
-  #else
-    for (int i = 0; i < CmiNumPes(); i++)
-      CmiSyncSend(i, size, msg);
-  #endif
   #else
     for (int i = 0; i < CmiNumPes(); i++)
       CmiSyncSend(i, size, msg);
@@ -103,20 +89,11 @@ void CmiSyncBroadcast(int size, void *msg) {
     CmiMessageHeader *header = static_cast<CmiMessageHeader *>(msg);
     header->messageSize = size;
   
-  #ifdef SPANTREE
-  #if SPANTREE ON
+  #if SPANTREE
     CmiSetBcastSource(msg, node); // used to skip the source
     header->swapHandlerId = header->handlerId;
     header->handlerId = Cmi_nodeBcastHandler;
     CmiSyncNodeSend(0, size, msg);
-  #else
-  
-    for (int i = node + 1; i < CmiNumNodes(); i++)
-      CmiSyncNodeSend(i, size, msg);
-  
-    for (int i = 0; i < node; i++)
-      CmiSyncNodeSend(i, size, msg);
-  #endif
   #else
   
     for (int i = node + 1; i < CmiNumNodes(); i++)
@@ -136,17 +113,11 @@ void CmiSyncBroadcast(int size, void *msg) {
     CmiMessageHeader *header = static_cast<CmiMessageHeader *>(msg);
     header->messageSize = size;
   
-  #ifdef SPANTREE
-  #if SPANTREE ON
+  #if SPANTREE
     CmiSetBcastSource(msg, -1); // don't skip the source
     header->swapHandlerId = header->handlerId;
     header->handlerId = Cmi_nodeBcastHandler;
     CmiSyncNodeSend(0, size, msg);
-  #else
-  
-    for (int i = 0; i < CmiNumNodes(); i++)
-      CmiSyncNodeSend(i, size, msg);
-  #endif
   #else
   
     for (int i = 0; i < CmiNumNodes(); i++)

--- a/src/converse_config.h.in
+++ b/src/converse_config.h.in
@@ -4,7 +4,7 @@
 #cmakedefine RECONVERSE_ENABLE_COMM_LCI2
 #cmakedefine RECONVERSE_ENABLE_COMM_LCW
 #cmakedefine RECONVERSE_ENABLE_CPU_AFFINITY
-#cmakedefine SPANTREE
+#cmakedefine01 SPANTREE
 #cmakedefine CMK_SMP
 #cmakedefine CMK_CPV_IS_SMP
 #cmakedefine CMK_USE_SHMEM


### PR DESCRIPTION
The cmake created the need for an awkward ifdef for the spantree option, so this fixes it.