### PR TITLE
Global cmibarrier

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -457,9 +457,9 @@ void CmiNetworkProgress();
 #define CmiNetworkProgressAfter(p) CmiNetworkProgressAfter()
 
 // Barrier functions
+void CmiBarrier();
 void CmiNodeBarrier();
 void CmiNodeAllBarrier();
-#define CmiBarrier() CmiNodeBarrier()
 
 // scheduler
 void CsdExitScheduler();

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -740,6 +740,14 @@ void CmiFreeDecrementToEnqueue(DecrementToEnqueueMsg *dteMsg){
   free(dteMsg);
 }
 
+void CmiBarrier(void) {
+  CmiNodeBarrier();
+  if (CmiMyRank() == 0) {
+    comm_backend::barrier();
+  }
+  CmiNodeBarrier();
+}
+
 void CmiNodeBarrier(void) {
   static Barrier nodeBarrier(CmiMyNodeSize());
   int64_t ticket = nodeBarrier.arrive();


### PR DESCRIPTION
Fixes the CmiBarrier() implementation to wait for all nodes, using the comm backend's barrier.