### PR TITLE
Fix bug in output of projections file

### DIFF
--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -158,7 +158,7 @@ void converseRunPe(int rank, int everReturn) {
   CpvAccess(isHelperOn) = 0;
 
   if (CmiTraceFn)
-    CmiTraceFn(Cmi_argv);
+    CmiTraceFn(CmiMyArgv);
 
   /*Converse modes:
   * usched=0, initret/everReturn=0: normal mode, converse starts scheduler for you


### PR DESCRIPTION
This fixes the processing of the +tracemode argument, and allows all projections files to be properly output to the specified directory.