### PR TITLE
update LCI to the latest version 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ option(RECONVERSE_TRY_ENABLE_COMM_LCI2 "whether to enable the LCIv2 backend" ON)
 option(RECONVERSE_AUTOFETCH_LCI2
         "whether to autofetch LCIv2 if LCI2 cannot be found" OFF)
 set(RECONVERSE_AUTOFETCH_LCI2_TAG
-    "ce2af2e0775552a9fa458979ce6b5199bc2febbc"
-    CACHE STRING "The tag to fetch for LCIv2") # master branch as of 2025-12-8
+    "bc25ce13ac94ed19301b0f84dbda4c8c0a73a037"
+    CACHE STRING "The tag to fetch for LCIv2") # master branch as of 2026-06-14
 
 option(RECONVERSE_TRY_ENABLE_COMM_LCW "whether to enable the LCW backend" ON)
 option(RECONVERSE_AUTOFETCH_LCW

--- a/include/conv-rdma.h
+++ b/include/conv-rdma.h
@@ -12,7 +12,7 @@ extern bool CmiUseCopyBasedRDMA;
 #define CMK_REG_REQUIRED 1
 // 8-byte for mr, 16-byte for rmr
 // TODO: better to use dynamic allocation and PUP
-#define CMK_NOCOPY_DIRECT_BYTES 24
+#define CMK_NOCOPY_DIRECT_BYTES 32
 
 /*********************************** Zerocopy Direct API
  * **********************************/


### PR DESCRIPTION
I fixed a bug related to using registration cache with the LCI ofi backend in the latest LCI version (https://github.com/uiuc-hpc/lci/pull/169). This PR updates reconverse to the latest LCI commit and increases `CMK_NOCOPY_DIRECT_BYTES` to accommodate the LCI `rmr_t` size change.