### PR TITLE
Add CMK_NOCOPY_DIRECT_BYTES to charm-config

### DIFF
--- a/include/charm-config.h
+++ b/include/charm-config.h
@@ -9,4 +9,9 @@
 
 #define CMK_LBDB_ON 1
 
+// Size of the machine-layer buffer in CmiNcpyBuffer::layerInfo.
+// Reconverse uses 8 bytes for mr_t + 16 bytes for rmr + 8 bytes spare = 32.
+// This must match CMK_NOCOPY_DIRECT_BYTES in reconverse/include/conv-rdma.h.
+#define CMK_NOCOPY_DIRECT_BYTES 32
+
 #endif


### PR DESCRIPTION
Needed to fix a bug in zero-copy communication in Charm++