### PR TITLE
Fix immediate lock implementation

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -735,15 +735,11 @@ int CmiArgGivingUsage(void);
 void CmiDeprecateArgInt(char **argv, const char *arg, const char *desc,
                         const char *warning);
 
-#define CmiCreateImmediateLock() (0)
-#define CmiImmediateLock(ignored)                                              \
-  { _immediateLock++; }
-#define CmiImmediateUnlock(ignored)                                            \
-  { _immediateLock--; }
-#define CmiCheckImmediateLock(ignored)                                         \
-  ((_immediateLock) ? ((_immediateFlag = 1), 1) : 0)
-#define CmiClearImmediateFlag()                                                \
-  { _immediateFlag = 0; }
+#define CmiCreateImmediateLock() CmiCreateLock()
+#define CmiImmediateLock(immediateLock) CmiLock((immediateLock))
+#define CmiImmediateUnlock(immediateLock) CmiUnlock((immediateLock))
+#define CmiCheckImmediateLock(ignored)  (0)
+#define CmiClearImmediateFlag() 
 #define CmiBecomeImmediate(msg) /* empty */
 #define CmiResetImmediate(msg)  /* empty */
 #define CmiIsImmediate(msg) (0)

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -31,6 +31,10 @@ void CsdScheduler() {
     #endif
 
     // poll node queue
+    // CmiNodeQueue is MPMC so the pop itself is thread-safe, but Charm++ node-level
+    // handlers (e.g. CkCreateLocalNodeGroup) modify shared data structures that are
+    // NOT thread-safe.  Serialize dispatch with CsdNodeQueueLock, matching the
+    // serialization guarantee that original Charm++ SMP provides for node messages.
     if (!nodeQueue->empty()) {
       auto result = nodeQueue->pop();
       if (result) {
@@ -207,7 +211,7 @@ void CsdSchedulePoll() {
 
     CcdRaiseCondition(CcdSCHEDLOOP);
 
-    // poll node queue
+    // poll node queue (same lock as CsdScheduler — see comment there)
     if (!nodeQueue->empty()) {
       auto result = nodeQueue->pop();
       if (result) {

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -31,10 +31,6 @@ void CsdScheduler() {
     #endif
 
     // poll node queue
-    // CmiNodeQueue is MPMC so the pop itself is thread-safe, but Charm++ node-level
-    // handlers (e.g. CkCreateLocalNodeGroup) modify shared data structures that are
-    // NOT thread-safe.  Serialize dispatch with CsdNodeQueueLock, matching the
-    // serialization guarantee that original Charm++ SMP provides for node messages.
     if (!nodeQueue->empty()) {
       auto result = nodeQueue->pop();
       if (result) {
@@ -211,7 +207,7 @@ void CsdSchedulePoll() {
 
     CcdRaiseCondition(CcdSCHEDLOOP);
 
-    // poll node queue (same lock as CsdScheduler — see comment there)
+    // poll node queue
     if (!nodeQueue->empty()) {
       auto result = nodeQueue->pop();
       if (result) {


### PR DESCRIPTION
The previous implementation for functions such as CmiCreateImmediateLock() ws inadvertently based on the non-SMP implementation in old converse, not SMP. This fixes the implementation, which also solves a race condition that occurs when 2 different node groups are initialized by different PEs on the same process (this causes a double free error when enlarging the _nodeGroupIDTable in CkCreateLocalNodeGroup in ck.C).