### PR TITLE
free parentBlk when refCount==1

### DIFF
--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -568,7 +568,7 @@ void CmiFree(void *msg) {
 
   if (refCount == 1) {
     //free(BLKSTART(parentBlk));
-    comm_backend::free(msg);
+    comm_backend::free(parentBlk);
   }
   
 }


### PR DESCRIPTION
CmiAllocFindEnclosing can return an enclosing block different from msg (when refcounts are negative). The old code freed BLKSTART(parentBlk), but the new code frees using msg, which can compute the wrong base pointer and corrupt memory. Free the enclosing block (parentBlk) instead.