### PR TITLE
RDMA fixes, including memory deregistration

### DIFF
--- a/include/conv-rdma.h
+++ b/include/conv-rdma.h
@@ -4,6 +4,21 @@
 #include "cmirdmautils.h"
 #include <functional>
 
+/* Reconverse itself has no PUP dependency, but Charm++ builds on top of this
+ * header and CkNcpyBuffer::pup() chains to CmiNcpyBuffer::pup(). pup.h is only
+ * present on the include path when this header is consumed as part of a
+ * Charm++ build (it is copied next to this file), so use its availability to
+ * decide whether to expose the PUP'd form. */
+#if defined(__has_include)
+#if __has_include("pup.h")
+#include "pup.h"
+#define CMK_NCPY_HAS_PUP 1
+#endif
+#endif
+#ifndef CMK_NCPY_HAS_PUP
+#define CMK_NCPY_HAS_PUP 0
+#endif
+
 // User specified configuration
 // TODO: move to a better location
 extern bool CmiUseCopyBasedRDMA;
@@ -258,18 +273,20 @@ public:
 #endif
   }
 
-  // void pup(PUP::er &p) {
-  //   p((char *)&ptr, sizeof(ptr));
-  //   p((char *)&ref, sizeof(ref));
-  //   p((char *)&refAckInfo, sizeof(refAckInfo));
-  //   p | cnt;
-  //   p | pe;
-  //   p | regMode;
-  //   p | deregMode;
-  //   p | isRegistered;
-  //   PUParray(p, layerInfo,
-  //            CMK_COMMON_NOCOPY_DIRECT_BYTES + CMK_NOCOPY_DIRECT_BYTES);
-  // }
+#if CMK_NCPY_HAS_PUP
+  void pup(PUP::er &p) {
+    p((char *)&ptr, sizeof(ptr));
+    p((char *)&ref, sizeof(ref));
+    p((char *)&refAckInfo, sizeof(refAckInfo));
+    p | cnt;
+    p | pe;
+    p | regMode;
+    p | deregMode;
+    p | isRegistered;
+    PUParray(p, layerInfo,
+             CMK_COMMON_NOCOPY_DIRECT_BYTES + CMK_NOCOPY_DIRECT_BYTES);
+  }
+#endif
 
   void memcpyGet(CmiNcpyBuffer &source);
   void memcpyPut(CmiNcpyBuffer &destination);

--- a/src/comm_backend/lci2/comm_backend_lci2.cpp
+++ b/src/comm_backend/lci2/comm_backend_lci2.cpp
@@ -203,6 +203,9 @@ void CommBackendLCI2::init(char **argv) {
 }
 
 void CommBackendLCI2::exit() {
+  // Drop any still-registered memory regions before tearing the devices down;
+  // an open region makes fi_close(domain) fail with FI_EBUSY.
+  deregisterAllMemory();
   for (auto device : m_devices) {
     lci::free_device(&device);
   }
@@ -341,6 +344,10 @@ mr_t CommBackendLCI2::registerMemory(void *addr, size_t size) {
     mrs[i] =
         lci::register_memory_x(addr, size).device(m_devices[i])().get_impl();
   }
+  {
+    std::lock_guard<std::mutex> lock(m_liveMrsMutex);
+    m_liveMrs.insert(mrs);
+  }
   return mrs;
 }
 
@@ -357,12 +364,36 @@ size_t CommBackendLCI2::getRMR(mr_t mr, void *addr, size_t size) {
 }
 
 void CommBackendLCI2::deregisterMemory(mr_t mr_) {
+  {
+    std::lock_guard<std::mutex> lock(m_liveMrsMutex);
+    m_liveMrs.erase(mr_);
+  }
   lci::mr_t *mrs = (lci::mr_t *)mr_;
   for (int i = 0; i < m_devices.size(); i++) {
     lci::mr_t mr(mrs[i]);
     lci::deregister_memory(&mr);
   }
   delete[] mrs;
+}
+
+// Release any memory regions the application never handed back, e.g. buffers
+// registered with CK_BUFFER_NODEREG. Must run while the devices are still alive
+// (deregisterMemory walks m_devices), so exit() calls this before free_device.
+void CommBackendLCI2::deregisterAllMemory() {
+  std::unordered_set<void *> leftovers;
+  {
+    std::lock_guard<std::mutex> lock(m_liveMrsMutex);
+    leftovers.swap(m_liveMrs);
+  }
+  // Deregister outside the lock: deregisterMemory() takes it too.
+  for (void *mr : leftovers) {
+    lci::mr_t *mrs = (lci::mr_t *)mr;
+    for (int i = 0; i < m_devices.size(); i++) {
+      lci::mr_t m(mrs[i]);
+      lci::deregister_memory(&m);
+    }
+    delete[] mrs;
+  }
 }
 
 lci::device_t CommBackendLCI2::getThreadLocalDevice() {

--- a/src/comm_backend/lci2/comm_backend_lci2.h
+++ b/src/comm_backend/lci2/comm_backend_lci2.h
@@ -4,6 +4,9 @@
 #include "lci.hpp"
 #include "comm_backend_internal.h"
 
+#include <mutex>
+#include <unordered_set>
+
 namespace comm_backend {
 namespace lci2_impl {
 // A breach of the comm_backend interface with direct access to CmiAlloc/CmiFree
@@ -68,6 +71,14 @@ private:
   lci::comp_t m_remote_comp;
   lci::rcomp_t m_rcomp;
   AllocatorLCI2 m_allocator;
+
+  // Memory regions handed out by registerMemory() that have not been given back
+  // to deregisterMemory(). A buffer registered with CK_BUFFER_NODEREG is never
+  // deregistered by the application, so without this the region is still open
+  // when exit() closes the device and fi_close(domain) fails with FI_EBUSY.
+  std::mutex m_liveMrsMutex;
+  std::unordered_set<void *> m_liveMrs;
+  void deregisterAllMemory();
 
   lci::device_t getThreadLocalDevice();
   lci::mr_t getThreadLocalMR(mr_t mr);

--- a/src/conv-rdma.cpp
+++ b/src/conv-rdma.cpp
@@ -362,7 +362,12 @@ void zcPupGet(CmiNcpyBuffer &src, CmiNcpyBuffer &dest) {
 // Invoked by the local completion of the Rput operation
 void CommRputLocalHandler(comm_backend::Status status) {
   NcpyOperationInfo *ncpyOpInfo = (NcpyOperationInfo *)status.user_context;
-  ncpyOpInfo->ackMode = CMK_SRC_ACK;
+  // Do not narrow ackMode here. A true RDMA put only raises a completion on the
+  // initiator, so this handler is responsible for both sides of the operation.
+  // The default ackMode set by setNcpyOpInfo is CMK_SRC_DEST_ACK, which lets the
+  // upper layer invoke the local ack directly and route the remote one to the
+  // peer PE. Narrowing it to CMK_SRC_ACK silently drops the destination ack, so
+  // the receiver's callback never runs.
   auto realFreeMe = ncpyOpInfo->freeMe;
   ncpyOpInfo->freeMe = CMK_DONT_FREE_NCPYOPINFO;
   ncpyDirectAckHandlerFn(ncpyOpInfo);
@@ -373,7 +378,8 @@ void CommRputLocalHandler(comm_backend::Status status) {
 // Invoked by the local completion of the Rget operation
 void CommRgetLocalHandler(comm_backend::Status status) {
   NcpyOperationInfo *ncpyOpInfo = (NcpyOperationInfo *)status.user_context;
-  ncpyOpInfo->ackMode = CMK_DEST_ACK;
+  // See CommRputLocalHandler: leave ackMode at its CMK_SRC_DEST_ACK default so
+  // the source ack is not dropped.
   auto realFreeMe = ncpyOpInfo->freeMe;
   ncpyOpInfo->freeMe = CMK_DONT_FREE_NCPYOPINFO;
   ncpyDirectAckHandlerFn(ncpyOpInfo);

--- a/src/conv-rdma.cpp
+++ b/src/conv-rdma.cpp
@@ -45,23 +45,38 @@ static void remoteDeregHandler(ConverseRdmaMsg *deregMsg) {
 
   resetNcpyOpInfoPointers(ncpyOpInfo);
 
+  // The NcpyOperationInfo is embedded in deregMsg, so it is not an independent
+  // allocation and must not be freed by the upper layer; deregMsg is released
+  // at the end of this handler instead.
   ncpyOpInfo->freeMe = CMK_DONT_FREE_NCPYOPINFO;
 
-  if (CmiMyPe() == ncpyOpInfo->srcPe) {
-    ncpyOpInfo->ackMode = CMK_SRC_ACK;
+  // Compare by node, not PE: in SMP the buffer's owning PE need not be the PE
+  // that happens to run this handler.
+  if (CmiMyNode() == CmiNodeOf(ncpyOpInfo->srcPe)) {
     CmiDeregisterMem(ncpyOpInfo->srcPtr,
                      ncpyOpInfo->srcLayerInfo + CmiGetRdmaCommonInfoSize(),
-                     ncpyOpInfo->srcPe, ncpyOpInfo->srcDeregMode);
-  } else if (CmiMyPe() == ncpyOpInfo->destPe) {
-    ncpyOpInfo->ackMode = CMK_DEST_ACK;
+                     ncpyOpInfo->srcPe, ncpyOpInfo->srcRegMode);
+    ncpyOpInfo->isSrcRegistered = 0;
+    ncpyOpInfo->ackMode = CMK_SRC_ACK;
+    // Downgrade opMode so the upper layer only invokes the source callback.
+    // Leaving the original opMode (e.g. CMK_EM_API) would re-run the whole
+    // completion path here, which would send another dereg message back and
+    // loop forever, and would leak an unmatched QdCreate on every pass.
+    ncpyOpInfo->opMode = CMK_EM_API_SRC_ACK_INVOKE;
+  } else if (CmiMyNode() == CmiNodeOf(ncpyOpInfo->destPe)) {
     CmiDeregisterMem(ncpyOpInfo->destPtr,
                      ncpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(),
-                     ncpyOpInfo->destPe, ncpyOpInfo->destDeregMode);
+                     ncpyOpInfo->destPe, ncpyOpInfo->destRegMode);
+    ncpyOpInfo->isDestRegistered = 0;
+    ncpyOpInfo->ackMode = CMK_DEST_ACK;
+    ncpyOpInfo->opMode = CMK_EM_API_DEST_ACK_INVOKE;
   } else {
-    CmiAbort("remoteDeregHandler: Invalid PE\n");
+    CmiAbort("remoteDeregHandler: neither source nor destination node\n");
   }
 
   ncpyDirectAckHandlerFn(ncpyOpInfo);
+
+  CmiFree(deregMsg);
 }
 
 // Invoked when this PE has to send a large array for an Rget


### PR DESCRIPTION
Intended to fix issue #188. ~~Reconverse was inadvertently overrwriting CMK_SRC_DEST_ACK to CMK_SRC_ACK, causing an error with destination ACKing. This fixes that (allowing the pingpong results to show for nodegroups) but isn't complete yet, there needs to be code to clean up RDMA buffers. currently this error happens at the end:~~

```
------- Processor 0 Exiting: Called CmiAbort ------
Reason: Unhandled C++ exception in user code: 0:55075:0:/Users/ritvik/charm_reconverse/reconverse-darwin-arm8/_deps/lci-src/src/network/ofi/backend_ofi.cpp:~ofi_device_impl_t:327<lci:Assert failed: false> err : Resource busy (/Users/ritvik/charm_reconverse/reconv
/Users/ritvik/charm_reconverse/reconverse-darwin-arm8/_deps/lci-src/lcrun: line 39: 55075 Segmentation fault: 11  "$@"
/Users/ritvik/charm_reconverse/reconverse-darwin-arm8/_deps/lci-src/lcrun: line 39: 55076 Segmentation fault: 11  "$@"
```

update: All RDMA tests now pass and pingpong runs correctly. This pr changes 2 things:

* adds CK_BUFFER_DEREG to charm-config.h, and other changes to allow Charm++ to use conv-rdma.h from reconverse, not old converse
* adds logic to deregister all RDMA buffers on exit

Using these changes requires the reconverse-rdma-fixes branch of Charm++; once this is merged into main, the reconverse-rdma-fixes branch will be merged into reconverse-specific-build in the charm repo