### PR TITLE
New benchmarks for ULT performance

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(task_queue)
 add_subdirectory(cth)
 add_subdirectory(self_send)
 add_subdirectory(ctv)
+add_subdirectory(ult_bench)
 
 # Add a test that configures, builds, and runs standalone_project
 add_test(NAME standalone_project_build_and_test

--- a/tests/ult_bench/CMakeLists.txt
+++ b/tests/ult_bench/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_reconverse_executable(sched_rate sched_rate.cpp)
+add_test(NAME ult_sched_rate COMMAND sched_rate +pe 4 -threads 16 -yields 100 -reps 2)
+
+add_reconverse_executable(ctxswitch ctxswitch.cpp)
+add_test(NAME ult_ctxswitch COMMAND ctxswitch +pe 4 -max_flows 16 -switches 10000 -reps 2)
+
+# the only target here that needs C++20; the rest of the tree is C++11
+add_reconverse_executable(am_vs_coro am_vs_coro.cpp)
+set_target_properties(am_vs_coro PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
+add_test(NAME ult_am_vs_coro COMMAND am_vs_coro +pe 4 -flows 8 -events 20000 -reps 2)

--- a/tests/ult_bench/am_vs_coro.cpp
+++ b/tests/ult_bench/am_vs_coro.cpp
@@ -1,0 +1,320 @@
+/**
+  Compares the scheduling rate of Converse active messages against the
+  scheduling rate of C++20 coroutines.
+
+  All three models are measured identically: -flows work items are kept in
+  flight, a dispatch does nothing but hand control to the next item, and the
+  reported number is elapsed / dispatches.
+
+    coro      A coroutine handle is popped from a plain single-threaded ring
+              FIFO, resumed to its next co_await, and pushed back. Nothing of
+              the runtime is involved, so this is the floor: what a coroutine
+              dispatch costs when the scheduler around it is as cheap as a
+              scheduler can be.
+
+    am        An active message is pushed onto this PE's queue with CmiPushPE,
+              popped by CsdScheduler, and handed to its handler, which pushes it
+              again. This is the runtime's real scheduling path -- the same
+              queue and the same loop CthAwaken and ULT dispatch go through --
+              so it carries the concurrent queue and the scheduler loop's
+              per-iteration polling.
+
+    coro+am   The two composed: every coroutine is driven by its own active
+              message, so a dispatch is a queue pop, a handler call, and a
+              resume. This is what coroutines would cost if this runtime
+              scheduled them, and (coro+am - am) isolates what the resume adds
+              on top of an active message.
+
+  The gap between `coro` and `am` is therefore mostly the queue and scheduler
+  loop, not the dispatch mechanism; `coro+am` is the number to use when asking
+  whether coroutines are cheaper than what the runtime already does.
+
+  Usage: reconverse_am_vs_coro +pe N [-flows K] [-events M] [-reps R]
+  */
+#include "converse.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#if defined(__cpp_impl_coroutine) || __cplusplus >= 202002L
+#define HAVE_CORO 1
+#include <coroutine>
+#else
+#define HAVE_CORO 0
+#endif
+
+#define DEFAULT_FLOWS 64
+#define DEFAULT_EVENTS 1000000
+#define DEFAULT_REPS 5
+
+enum { PH_CORO = 0, PH_AM = 1, PH_CORO_AM = 2, PH_COUNT = 3 };
+static const char *phaseName[PH_COUNT] = {"coro", "am", "coro+am"};
+
+struct benchMsg {
+  char header[CmiMsgHeaderSizeBytes];
+  int index; /* which coroutine this message drives */
+};
+
+struct amBench {
+  int flows;
+  int nreps;
+  long events;  /* target dispatches per rep */
+  int phase;
+  int rep;      /* -1 during each phase's warmup rep */
+  long count;   /* dispatches so far this rep */
+  long retired; /* messages that have stopped re-enqueueing */
+  double start;
+  double best[PH_COUNT], total[PH_COUNT];
+  void **msgs;  /* `flows` reusable messages */
+  void **coros; /* `flows` coroutine handle addresses */
+};
+
+CpvStaticDeclare(struct amBench, bench);
+CpvStaticDeclare(int, amHandlerIdx);
+CpvStaticDeclare(int, coroAmHandlerIdx);
+
+static void startPhaseRep(void);
+
+#if HAVE_CORO
+struct Task {
+  struct promise_type {
+    Task get_return_object() {
+      return Task{std::coroutine_handle<promise_type>::from_promise(*this)};
+    }
+    std::suspend_always initial_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() noexcept { return {}; }
+    void return_void() {}
+    void unhandled_exception() { abort(); }
+  };
+  std::coroutine_handle<promise_type> h;
+};
+
+/* Suspends at every step and never finishes: the driver resumes it a fixed
+   number of times and destroys it afterwards, so a dispatch is exactly one
+   resume and one suspend with no completion test to pay for. */
+static Task stepCoro(void) {
+  for (;;)
+    co_await std::suspend_always{};
+}
+
+static inline void resumeCoro(void *addr) {
+  std::coroutine_handle<>::from_address(addr).resume();
+}
+#else
+static inline void resumeCoro(void *addr) { (void)addr; }
+#endif
+
+/* ------------------------------ reporting ------------------------------ */
+
+static void recordRep(double elapsed, long dispatches) {
+  struct amBench *d = &CpvAccess(bench);
+  double usEach = 1.0e6 * elapsed / (double)dispatches;
+
+  if (d->rep >= 0) { /* the warmup rep is measured but not recorded */
+    d->total[d->phase] += usEach;
+    if (usEach < d->best[d->phase])
+      d->best[d->phase] = usEach;
+    CmiPrintf("[PE %d] %-7s rep %d: %ld dispatches in %.6f s -> %.3f M/s, "
+              "%.4f us each\n",
+              CmiMyPe(), phaseName[d->phase], d->rep, dispatches, elapsed,
+              1.0e-6 * dispatches / elapsed, usEach);
+  }
+}
+
+static void report(void) {
+  struct amBench *d = &CpvAccess(bench);
+
+  for (int p = 0; p < PH_COUNT; p++)
+    CmiPrintf("[PE %d] %-7s: best %.4f us/dispatch (%.3f M/s), mean %.4f us\n",
+              CmiMyPe(), phaseName[p], d->best[p], 1.0 / d->best[p],
+              d->total[p] / d->nreps);
+  CmiPrintf("[PE %d] coroutine resume on top of an active message: %.4f us\n",
+            CmiMyPe(), d->best[PH_CORO_AM] - d->best[PH_AM]);
+  CmiPrintf("[PE %d] runtime scheduling on top of a bare resume: %.4f us\n",
+            CmiMyPe(), d->best[PH_CORO_AM] - d->best[PH_CORO]);
+  CmiPrintf("Format: DATA,am_vs_coro,{pe},{flows},{coro us},{am us},{coro+am "
+            "us}\n");
+  CmiPrintf("DATA,am_vs_coro,%d,%d,%f,%f,%f\n", CmiMyPe(), d->flows,
+            d->best[PH_CORO], d->best[PH_AM], d->best[PH_CORO_AM]);
+}
+
+static void advance(void) {
+  struct amBench *d = &CpvAccess(bench);
+
+  d->rep++;
+  if (d->rep < d->nreps) {
+    startPhaseRep();
+    return;
+  }
+
+  d->phase++;
+  d->rep = -1;
+  if (d->phase < PH_COUNT) {
+    startPhaseRep();
+    return;
+  }
+
+  report();
+#if HAVE_CORO
+  for (int i = 0; i < d->flows; i++)
+    std::coroutine_handle<>::from_address(d->coros[i]).destroy();
+#endif
+  for (int i = 0; i < d->flows; i++)
+    CmiFree(d->msgs[i]);
+  free(d->msgs);
+  free(d->coros);
+  CsdExitScheduler();
+}
+
+/* --------------------- phase 1: bare coroutine loop --------------------- */
+
+static void coroRep(void) {
+  struct amBench *d = &CpvAccess(bench);
+
+  /* a real FIFO, just the cheapest one that exists: a fixed ring with room
+     for every handle plus the empty slot that separates head from tail */
+  const int cap = d->flows + 1;
+  void **q = (void **)malloc(cap * sizeof(void *));
+  int head = 0, tail = 0;
+  for (int i = 0; i < d->flows; i++)
+    q[tail++] = d->coros[i];
+
+  double t0 = CmiWallTimer();
+  for (long n = 0; n < d->events; n++) {
+    void *addr = q[head];
+    head = (head + 1 == cap) ? 0 : head + 1;
+    resumeCoro(addr);
+    q[tail] = addr;
+    tail = (tail + 1 == cap) ? 0 : tail + 1;
+  }
+  double elapsed = CmiWallTimer() - t0;
+
+  free(q);
+  recordRep(elapsed, d->events);
+}
+
+/* ------------------- phases 2 and 3: active messages ------------------- */
+
+static void endAmRep(void) {
+  struct amBench *d = &CpvAccess(bench);
+  /* count, not events: the drain below lets a few extra dispatches through */
+  recordRep(CmiWallTimer() - d->start, d->count);
+  advance();
+}
+
+static void amHandler(void *msg) {
+  struct amBench *d = &CpvAccess(bench);
+  if (++d->count < d->events) {
+    CmiPushPE(CmiMyRank(), msg);
+    return;
+  }
+  if (++d->retired == d->flows) /* every message has come to rest */
+    endAmRep();
+}
+
+static void coroAmHandler(void *msg) {
+  struct amBench *d = &CpvAccess(bench);
+  resumeCoro(d->coros[((struct benchMsg *)msg)->index]);
+  if (++d->count < d->events) {
+    CmiPushPE(CmiMyRank(), msg);
+    return;
+  }
+  if (++d->retired == d->flows)
+    endAmRep();
+}
+
+static void startAmRep(void) {
+  struct amBench *d = &CpvAccess(bench);
+  const int handler = (d->phase == PH_AM) ? CpvAccess(amHandlerIdx)
+                                          : CpvAccess(coroAmHandlerIdx);
+  d->count = 0;
+  d->retired = 0;
+  for (int i = 0; i < d->flows; i++)
+    CmiSetHandler(d->msgs[i], handler);
+
+  d->start = CmiWallTimer();
+  for (int i = 0; i < d->flows; i++)
+    CmiPushPE(CmiMyRank(), d->msgs[i]);
+  /* the scheduler drains from here; endAmRep() picks it back up */
+}
+
+static void startPhaseRep(void) {
+  if (CpvAccess(bench).phase == PH_CORO) {
+    coroRep();
+    advance();
+  } else {
+    startAmRep();
+  }
+}
+
+/* -------------------------------- setup -------------------------------- */
+
+static void bench_init(int argc, char **argv) {
+  (void)argc;
+
+  CpvInitialize(struct amBench, bench);
+  CpvInitialize(int, amHandlerIdx);
+  CpvInitialize(int, coroAmHandlerIdx);
+  CpvAccess(amHandlerIdx) = CmiRegisterHandler((CmiHandler)amHandler);
+  CpvAccess(coroAmHandlerIdx) = CmiRegisterHandler((CmiHandler)coroAmHandler);
+
+  struct amBench *d = &CpvAccess(bench);
+  d->flows = DEFAULT_FLOWS;
+  d->nreps = DEFAULT_REPS;
+  int events = DEFAULT_EVENTS;
+  CmiGetArgInt(argv, "-flows", &d->flows);
+  CmiGetArgInt(argv, "-events", &events);
+  CmiGetArgInt(argv, "-reps", &d->nreps);
+  d->events = events;
+
+  if (d->flows < 1 || d->events < d->flows || d->nreps < 1) {
+    if (CmiMyPe() == 0)
+      CmiPrintf("Error: need -flows >= 1, -events >= flows and -reps >= 1 "
+                "(got %d, %d, %d), exiting\n",
+                d->flows, events, d->nreps);
+    CmiExit(1); /* only queues the exit, so stop here ourselves */
+    return;
+  }
+
+#if !HAVE_CORO
+  if (CmiMyPe() == 0)
+    CmiPrintf("note: built without C++20 coroutine support, the coro and "
+              "coro+am phases measure an empty resume\n");
+#endif
+
+  d->phase = PH_CORO;
+  d->rep = -1;
+  d->count = d->retired = 0;
+  for (int p = 0; p < PH_COUNT; p++) {
+    d->best[p] = 1.0e30;
+    d->total[p] = 0.0;
+  }
+
+  d->msgs = (void **)malloc(d->flows * sizeof(void *));
+  d->coros = (void **)malloc(d->flows * sizeof(void *));
+  for (int i = 0; i < d->flows; i++) {
+    struct benchMsg *m = (struct benchMsg *)CmiAlloc(sizeof(struct benchMsg));
+    m->index = i;
+    /* CmiPushPE(rank, msg) reads the size back out of the header */
+    ((CmiMessageHeader *)m)->messageSize = sizeof(struct benchMsg);
+    d->msgs[i] = m;
+#if HAVE_CORO
+    d->coros[i] = stepCoro().h.address();
+#else
+    d->coros[i] = NULL;
+#endif
+  }
+
+  if (CmiMyPe() == 0)
+    CmiPrintf("Active message vs C++ coroutine scheduling: %d flows, "
+              "%ld dispatches x %d reps (+1 warmup) per phase, on %d PEs\n",
+              d->flows, d->events, d->nreps, CmiNumPes());
+
+  /* skip the communication thread */
+  if (CmiMyRank() != CmiMyNodeSize())
+    startPhaseRep();
+}
+
+int main(int argc, char **argv) {
+  ConverseInit(argc, argv, bench_init);
+  return 0;
+}

--- a/tests/ult_bench/ctxswitch.cpp
+++ b/tests/ult_bench/ctxswitch.cpp
@@ -1,0 +1,224 @@
+/**
+  Measures ULT context switch time as a function of the number of concurrent
+  ULTs ("flows"): one row per flow count, sweeping -min_flows to -max_flows by
+  doubling. Plot column 4 (flows) against column 5 (us/switch).
+
+  Two costs are reported at every point, because "context switch" has two
+  meanings in this runtime and they differ by more than 10x:
+
+    direct    The `flows` ULTs are wired into a ring and hand control to their
+              successor with CthResume(), a single swapcontext with no queue
+              involved. This is the switch primitive alone, and it is the curve
+              that shows the stack working set growing: the only thing that
+              changes across the sweep is how many stacks the switches touch.
+
+    scheduler The same `flows` ULTs hand control to each other with CthYield(),
+              which is what application code writes: awaken self, suspend to the
+              scheduling thread, let the scheduler pop the next token and resume
+              it. That is two swapcontexts plus a queue push/pop and a handler
+              dispatch.
+
+  Both phases hold the total switch count per rep fixed at -switches regardless
+  of the flow count, so every point on the curve does the same amount of work
+  and only the concurrency varies.
+
+  Note that memory use is flows * -stack bytes, so raising -max_flows past a few
+  thousand at the default stack size wants a look at available RAM.
+
+  Usage: reconverse_ctxswitch +pe N [-min_flows F] [-max_flows F]
+                                    [-switches S] [-reps R] [-stack B]
+  */
+#include "converse.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DEFAULT_MIN_FLOWS 2
+#define DEFAULT_MAX_FLOWS 1024
+#define DEFAULT_SWITCHES 200000
+#define DEFAULT_REPS 5
+#define DEFAULT_STACK 65536
+#define WARMUP_LAPS 100
+
+struct ctxBench {
+  int minFlows, maxFlows;
+  int nswitches; /* switches per timed rep, held fixed across the sweep */
+  int nreps;
+  int stack;
+  int flows;       /* flow count at the current point of the sweep */
+  int alive;       /* scheduler-phase peers still running */
+  int done;        /* tells the scheduler-phase peers to stop yielding */
+  CthThread *ring; /* `flows` entries; ring[0] is the driver itself */
+};
+
+CpvStaticDeclare(struct ctxBench, bench);
+
+/* ------------------- direct: CthResume around a ring ------------------- */
+
+static void ringFn(void *arg) {
+  struct ctxBench *d = &CpvAccess(bench);
+  long i = (long)(intptr_t)arg;
+  /* safe to read the ring here: nothing resumes us until it is fully built */
+  CthThread next = d->ring[(i + 1) % d->flows];
+  /* Runs until the driver stops going around the ring, then stays suspended
+     inside CthResume; the driver frees us afterwards. */
+  for (;;)
+    CthResume(next);
+}
+
+static double directPoint(void) {
+  struct ctxBench *d = &CpvAccess(bench);
+  const int flows = d->flows;
+  int laps = d->nswitches / flows;
+  if (laps < 1)
+    laps = 1;
+
+  d->ring = (CthThread *)malloc(flows * sizeof(CthThread));
+  d->ring[0] = CthSelf();
+  for (long i = 1; i < flows; i++)
+    d->ring[i] = CthCreate((CthVoidFn)ringFn, (void *)(intptr_t)i, d->stack);
+
+  /* also runs each ring member up to its loop for the first time */
+  for (int i = 0; i < WARMUP_LAPS; i++)
+    CthResume(d->ring[1]);
+
+  double best = 1.0e30;
+  for (int rep = 0; rep < d->nreps; rep++) {
+    double t0 = CmiWallTimer();
+    for (int lap = 0; lap < laps; lap++)
+      CthResume(d->ring[1]);
+    double elapsed = CmiWallTimer() - t0;
+
+    /* one lap is `flows` switches: 0->1, 1->2, ... (flows-1)->0 */
+    double usEach = 1.0e6 * elapsed / ((double)laps * flows);
+    if (usEach < best)
+      best = usEach;
+  }
+
+  for (int i = 1; i < flows; i++)
+    CthFree(d->ring[i]); /* suspended in CthResume, never resumed again */
+  free(d->ring);
+  d->ring = NULL;
+  return best;
+}
+
+/* ---------------- scheduler-mediated: CthYield round robin ---------------- */
+
+static void yieldPeerFn(void *arg) {
+  (void)arg;
+  struct ctxBench *d = &CpvAccess(bench);
+  while (!d->done)
+    CthYield();
+  d->alive--;
+}
+
+static double yieldPoint(void) {
+  struct ctxBench *d = &CpvAccess(bench);
+  const int flows = d->flows;
+  int per = d->nswitches / flows; /* yields by the driver, per rep */
+  if (per < 1)
+    per = 1;
+
+  d->done = 0;
+  d->alive = flows - 1;
+  for (int i = 1; i < flows; i++)
+    CthAwaken(CthCreate((CthVoidFn)yieldPeerFn, 0, d->stack));
+
+  for (int i = 0; i < WARMUP_LAPS; i++)
+    CthYield();
+
+  double best = 1.0e30;
+  for (int rep = 0; rep < d->nreps; rep++) {
+    double t0 = CmiWallTimer();
+    for (int i = 0; i < per; i++)
+      CthYield();
+    double elapsed = CmiWallTimer() - t0;
+
+    /* The ready queue is FIFO and holds exactly these `flows` ULTs, so they
+       rotate strictly: every one of them yields once per driver yield, giving
+       per * flows handoffs inside the window. */
+    double usEach = 1.0e6 * elapsed / ((double)per * flows);
+    if (usEach < best)
+      best = usEach;
+  }
+
+  d->done = 1;
+  while (d->alive > 0) /* let every peer wake up once and exit */
+    CthYield();
+  return best;
+}
+
+/* ------------------------------- sweep ------------------------------- */
+
+static void driverFn(void *arg) {
+  (void)arg;
+  struct ctxBench *d = &CpvAccess(bench);
+
+  for (int f = d->minFlows;; f *= 2) {
+    d->flows = f;
+    double direct = directPoint();
+    double sched = yieldPoint();
+
+    CmiPrintf("[PE %d] flows=%5d: direct %.4f us/switch (%.3f M/s), "
+              "scheduler %.4f us/switch (%.3f M/s)\n",
+              CmiMyPe(), f, direct, 1.0 / direct, sched, 1.0 / sched);
+    CmiPrintf("DATA,ctxswitch,%d,%d,%f,%f\n", CmiMyPe(), f, direct, sched);
+
+    if (f > d->maxFlows / 2) /* doubling again would pass max_flows */
+      break;
+  }
+
+  CsdExitScheduler();
+}
+
+static void bench_init(int argc, char **argv) {
+  (void)argc;
+
+  CpvInitialize(struct ctxBench, bench);
+  struct ctxBench *d = &CpvAccess(bench);
+  d->minFlows = DEFAULT_MIN_FLOWS;
+  d->maxFlows = DEFAULT_MAX_FLOWS;
+  d->nswitches = DEFAULT_SWITCHES;
+  d->nreps = DEFAULT_REPS;
+  d->stack = DEFAULT_STACK;
+  CmiGetArgInt(argv, "-min_flows", &d->minFlows);
+  CmiGetArgInt(argv, "-max_flows", &d->maxFlows);
+  CmiGetArgInt(argv, "-switches", &d->nswitches);
+  CmiGetArgInt(argv, "-reps", &d->nreps);
+  CmiGetArgInt(argv, "-stack", &d->stack);
+
+  /* one flow cannot switch to anything but itself, so the ring needs two */
+  if (d->minFlows < 2 || d->maxFlows < d->minFlows || d->nswitches < 1 ||
+      d->nreps < 1 || d->stack < 4096) {
+    if (CmiMyPe() == 0)
+      CmiPrintf("Error: need -min_flows >= 2, -max_flows >= min_flows, "
+                "-switches >= 1, -reps >= 1 and -stack >= 4096 "
+                "(got %d, %d, %d, %d, %d), exiting\n",
+                d->minFlows, d->maxFlows, d->nswitches, d->nreps, d->stack);
+    CmiExit(1); /* only queues the exit, so stop here ourselves */
+    return;
+  }
+
+  d->flows = 0;
+  d->alive = 0;
+  d->done = 0;
+  d->ring = NULL;
+
+  if (CmiMyPe() == 0) {
+    CmiPrintf("ULT context switch vs concurrency: flows %d..%d (doubling), "
+              "%d switches x %d reps per point, %d byte stacks, on %d PEs\n",
+              d->minFlows, d->maxFlows, d->nswitches, d->nreps, d->stack,
+              CmiNumPes());
+    CmiPrintf("Format: DATA,ctxswitch,{pe},{flows},{direct us/switch},"
+              "{scheduler us/switch}\n");
+  }
+
+  /* skip the communication thread */
+  if (CmiMyRank() != CmiMyNodeSize())
+    CthAwaken(CthCreate((CthVoidFn)driverFn, 0, d->stack));
+}
+
+int main(int argc, char **argv) {
+  ConverseInit(argc, argv, bench_init);
+  return 0;
+}

--- a/tests/ult_bench/sched_rate.cpp
+++ b/tests/ult_bench/sched_rate.cpp
@@ -1,0 +1,155 @@
+/**
+  Measures how fast the Converse scheduler dispatches ready user-level threads
+  (ULTs).
+
+  A "dispatch" is one trip through the scheduler's ready path: CthAwaken pushes
+  the thread's token onto this PE's queue, CsdScheduler pops it, and
+  CthResumeNormalThread resumes the thread. Each PE runs -threads ULTs that each
+  call CthYield() -yields times, so a repetition performs
+
+      threads * (yields + 1)
+
+  dispatches: one for the initial awaken, plus one per yield.
+
+  -threads sets how many ULTs are runnable at once, i.e. the depth of the ready
+  queue. Sweeping it shows how the dispatch rate holds up as the queue fills and
+  the working set of thread stacks stops fitting in cache.
+
+  CthCreate is deliberately kept outside the timed region and reported
+  separately: it mallocs a stack, which would otherwise dominate at low -yields.
+
+  Usage: reconverse_sched_rate +pe N [-threads T] [-yields Y] [-reps R] [-stack B]
+  */
+#include "converse.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DEFAULT_THREADS 64
+#define DEFAULT_YIELDS 1000
+#define DEFAULT_REPS 5
+#define DEFAULT_STACK 65536
+
+struct schedBench {
+  int nthreads;      /* ULTs runnable at once */
+  int nyields;       /* CthYield() calls per ULT */
+  int nreps;         /* timed repetitions, after one warmup rep */
+  int stack;         /* per-ULT stack size in bytes */
+  int rep;           /* current rep, -1 during warmup */
+  int running;       /* ULTs still alive in this rep */
+  double repStart;   /* wall time when the timed region opened */
+  double createTime; /* CthCreate time for this rep, excluded from the timing */
+  double best;       /* lowest us/dispatch over the timed reps */
+  double total;      /* summed us/dispatch over the timed reps */
+};
+
+CpvStaticDeclare(struct schedBench, bench);
+
+static void startRep(void);
+static void finishRep(void);
+
+static void yielderFn(void *arg) {
+  (void)arg;
+  const int nyields = CpvAccess(bench).nyields;
+  for (int i = 0; i < nyields; i++)
+    CthYield();
+
+  /* ULTs on a PE are cooperative, so this needs no atomics */
+  if (--CpvAccess(bench).running == 0)
+    finishRep();
+}
+
+static void startRep(void) {
+  struct schedBench *d = &CpvAccess(bench);
+  CthThread *threads = (CthThread *)malloc(d->nthreads * sizeof(CthThread));
+  d->running = d->nthreads;
+
+  double t0 = CmiWallTimer();
+  for (int i = 0; i < d->nthreads; i++)
+    threads[i] = CthCreate((CthVoidFn)yielderFn, 0, d->stack);
+  d->createTime = CmiWallTimer() - t0;
+
+  /* time only the awaken/dispatch path */
+  d->repStart = CmiWallTimer();
+  for (int i = 0; i < d->nthreads; i++)
+    CthAwaken(threads[i]);
+  free(threads);
+  /* the ULTs free themselves as they exit, so there is nothing to reclaim */
+}
+
+static void finishRep(void) {
+  struct schedBench *d = &CpvAccess(bench);
+  double elapsed = CmiWallTimer() - d->repStart;
+  double dispatches = (double)d->nthreads * (d->nyields + 1);
+  double usEach = 1.0e6 * elapsed / dispatches;
+
+  if (d->rep >= 0) { /* the warmup rep is measured but not recorded */
+    d->total += usEach;
+    if (usEach < d->best)
+      d->best = usEach;
+    CmiPrintf("[PE %d] rep %d: %.0f dispatches in %.6f s -> %.3f M/s, "
+              "%.4f us each (create %.3f us/thread)\n",
+              CmiMyPe(), d->rep, dispatches, elapsed,
+              1.0e-6 * dispatches / elapsed, usEach,
+              1.0e6 * d->createTime / d->nthreads);
+  }
+
+  d->rep++;
+  if (d->rep < d->nreps) {
+    startRep();
+    return;
+  }
+
+  double mean = d->total / d->nreps;
+  CmiPrintf("[PE %d] threads=%d yields=%d: best %.4f us/dispatch "
+            "(%.3f M dispatches/s), mean %.4f us\n",
+            CmiMyPe(), d->nthreads, d->nyields, d->best, 1.0 / d->best, mean);
+  CmiPrintf("Format: DATA,sched_rate,{pe},{threads},{yields},{best "
+            "us/dispatch},{mean us/dispatch},{best M dispatch/s}\n");
+  CmiPrintf("DATA,sched_rate,%d,%d,%d,%f,%f,%f\n", CmiMyPe(), d->nthreads,
+            d->nyields, d->best, mean, 1.0 / d->best);
+
+  CsdExitScheduler();
+}
+
+static void bench_init(int argc, char **argv) {
+  (void)argc;
+
+  CpvInitialize(struct schedBench, bench);
+  struct schedBench *d = &CpvAccess(bench);
+  d->nthreads = DEFAULT_THREADS;
+  d->nyields = DEFAULT_YIELDS;
+  d->nreps = DEFAULT_REPS;
+  d->stack = DEFAULT_STACK;
+  CmiGetArgInt(argv, "-threads", &d->nthreads);
+  CmiGetArgInt(argv, "-yields", &d->nyields);
+  CmiGetArgInt(argv, "-reps", &d->nreps);
+  CmiGetArgInt(argv, "-stack", &d->stack);
+
+  if (d->nthreads < 1 || d->nyields < 0 || d->nreps < 1 || d->stack < 4096) {
+    if (CmiMyPe() == 0)
+      CmiPrintf("Error: need -threads >= 1, -yields >= 0, -reps >= 1 and "
+                "-stack >= 4096 (got %d, %d, %d, %d), exiting\n",
+                d->nthreads, d->nyields, d->nreps, d->stack);
+    CmiExit(1); /* only queues the exit, so stop here ourselves */
+    return;
+  }
+
+  d->rep = -1;
+  d->running = 0;
+  d->best = 1.0e30;
+  d->total = 0.0;
+
+  if (CmiMyPe() == 0)
+    CmiPrintf("ULT scheduling rate: %d threads x %d yields, %d reps "
+              "(+1 warmup), %d byte stacks, on %d PEs\n",
+              d->nthreads, d->nyields, d->nreps, d->stack, CmiNumPes());
+
+  /* skip the communication thread */
+  if (CmiMyRank() != CmiMyNodeSize())
+    startRep();
+}
+
+int main(int argc, char **argv) {
+  ConverseInit(argc, argv, bench_init);
+  return 0;
+}


### PR DESCRIPTION
Some benchmarks designed to test performance of various things, such as the cost of context switching for user-level threads and a comparison between the scheduling overhead of C++ coroutines and active messages.