### PR TITLE
Skip CcdCallBacks() when no timer callbacks are registered

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -659,6 +659,39 @@ void CcdCancelCallOnConditionKeep(int condnum, int idx);
 void CcdRaiseCondition(int condnum);
 void CcdCallBacks(void);
 
+/* How many callbacks are timer-based.  If none are, CcdCallBacks() has no
+   work to do and the scheduler can skip it outright. */
+int CcdNumTimerCBs(void);
+
+/* Countdown to the next CcdCallBacks(), maintained adaptively by
+   CcdCallBacks() itself so that it fires at roughly CCD_DEFAULT_RESOLUTION. */
+extern thread_local int _ccd_numchecks;
+
+/* The scheduler's periodic hook.
+ *
+ * Calling CcdCallBacks() unconditionally on every trip round the scheduler
+ * loop -- which is what this used to do -- costs a CmiWallTimer() (a clock
+ * read, ~60 ns on Delta) plus a heap probe every iteration, whether or not any
+ * timer callback exists.  For a program that registers none, which includes
+ * every Task Bench run, that is pure overhead on the hottest loop in the
+ * runtime.
+ *
+ * Both guards matter and they do different jobs.  The first collapses the
+ * whole thing to one predictable branch when nothing is timer-based.  The
+ * second bounds the cost when something is: CcdCallBacks() retunes
+ * _ccd_numchecks so the clock is read about every CCD_DEFAULT_RESOLUTION
+ * rather than every iteration.
+ *
+ * Ported from the original Converse (charm/src/conv-core/converse.h). */
+#define CsdPeriodic()                                                          \
+  do {                                                                         \
+    if ((CcdNumTimerCBs() > 0) && (_ccd_numchecks-- <= 0)) {                   \
+      CcdCallBacks();                                                          \
+    }                                                                          \
+  } while (0)
+
+#define CsdResetPeriodic() (_ccd_numchecks = 0)
+
 #define CQS_QUEUEING_FIFO 2
 #define CQS_QUEUEING_LIFO 3
 #define CQS_QUEUEING_IFIFO 4

--- a/src/conv-conds.cpp
+++ b/src/conv-conds.cpp
@@ -149,9 +149,14 @@ thread_local static struct ccd_cond_callbacks conds;
 /**
  * List of periodic callbacks maintained by the scheduler
  */
+// Default resolution of .005 seconds aka 5 milliseconds
+#define CCD_DEFAULT_RESOLUTION 5.0e-3
+
 struct ccd_periodic_callbacks {
   double lastCheck; /*Time of last check*/
   double nextCall[CCD_PERIODIC_MAX];
+  unsigned int nSkip;  /*Scheduler iterations to skip before checking again*/
+  double resolution;   /*How often the timer callbacks want to be serviced*/
 };
 
 /** */
@@ -218,6 +223,8 @@ void CcdModuleInit() {
   _ccd_num_timed_cond_cbs = 0;
   _ccd_numchecks = 1;
   double curTime = CmiWallTimer();
+  pcb.nSkip = 1;
+  pcb.resolution = CCD_DEFAULT_RESOLUTION;
   pcb.lastCheck = curTime;
   for (int i = 0; i < CCD_PERIODIC_MAX; i++)
     pcb.nextCall[i] = curTime + periodicCallInterval[i];
@@ -295,6 +302,27 @@ void CcdCallBacks(void) {
 
   /* Figure out how many times to skip Ccd processing */
   double curWallTime = CmiWallTimer();
+
+  /* Adjust the number of scheduler iterations to skip by a factor between
+     0.5, if we skipped too few last time, and 2, if we skipped too many.
+     Ideally elapsed == resolution and the multiplier is 1.  Without this the
+     scheduler would read the clock on every iteration once any timer callback
+     exists, which is what CsdPeriodic()'s second guard exists to prevent. */
+  unsigned int nSkip = o->nSkip;
+  double elapsed = curWallTime - o->lastCheck;
+  if (elapsed > 0.0) {
+    nSkip = (unsigned int)(nSkip * fmax(0.5, fmin(2.0, o->resolution / elapsed)));
+  }
+#define minSkip 1u
+#define maxSkip 20u
+  if (nSkip < minSkip)
+    nSkip = minSkip;
+  else if (nSkip > maxSkip)
+    nSkip = maxSkip;
+#undef minSkip
+#undef maxSkip
+
+  _ccd_numchecks = o->nSkip = nSkip;
   o->lastCheck = curWallTime;
 
   ccd_heap_update(curWallTime);
@@ -312,5 +340,9 @@ void CcdCallBacks(void) {
  */
 void CcdCallBacksReset(void *ignored) {
   ccd_periodic_callbacks *o = &pcb;
+  /* Something drastic changed (the PE went idle or came back), so the skip
+     count learned under the old conditions is stale -- check again next
+     iteration rather than coasting on it. */
+  _ccd_numchecks = o->nSkip = 1;
   o->lastCheck = CmiWallTimer();
 }

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -185,7 +185,7 @@ void CsdScheduler() {
       comm_backend::progress();
     }
 
-    CcdCallBacks();
+    CsdPeriodic();
 
   }
 }
@@ -203,7 +203,7 @@ void CsdSchedulePoll() {
 
   while(1){
 
-    CcdCallBacks();
+    CsdPeriodic();
 
     CcdRaiseCondition(CcdSCHEDLOOP);
 


### PR DESCRIPTION
CsdScheduler and CsdSchedulePoll called CcdCallBacks() unconditionally on every trip round the loop.  That costs a CmiWallTimer() (~60 ns on Delta) plus a heap probe per iteration even when no timer callback exists, which is the case for any program that does not register one.

Restore the original Converse guard: CcdNumTimerCBs() > 0 collapses the whole thing to one predictable branch when nothing is timer-based, and the _ccd_numchecks countdown bounds the cost when something is.  _ccd_numchecks was already declared here but never used to gate anything; the adaptive nSkip retuning that maintains it had been dropped in the port and is restored alongside it.

Verified against tests/conds: the 1s/5s/10s periodic conditions and the 7s CcdCallFnAfter all still fire, with no added lag.