### PR TITLE
Record-replay prerequisites: CpdSetInitializeMemory no-op, CsdEnqueue/CsdEnqueueLifo

### DIFF
--- a/include/converse.h
+++ b/include/converse.h
@@ -453,6 +453,8 @@ void CmiSyncSendAndFree(int destPE, int messageSize, void *msg);
 void CmiSyncListSend(int npes, const int *pes, int len, void *msg);
 void CmiSyncListSendAndFree(int npes, const int *pes, int len, void *msg);
 void CmiPushPE(int destRank, void *msg);
+void CsdEnqueue(void *msg);     /* classic scheduler-enqueue API; */
+void CsdEnqueueLifo(void *msg); /* FIFO here -- see convcore.cpp (record-replay) */
 void CmiPushNode(void *msg);
 
 void CmiSyncSendFn(int destPE, int messageSize, char *msg);

--- a/include/converse.h
+++ b/include/converse.h
@@ -422,6 +422,7 @@ extern void
 #define CMI_MEMORY_IS_CHARMDEBUG  (1<<6)
 int CmiMemoryIs(int flag); /* return state of this flag */
 void CpdSetInitializeMemory(int v); /* no-op outside charmdebug; needed by record-replay */
+CLINKAGE void CmiMkdir(const char *dirName);
 
 // state getters
 int CmiMyPe();

--- a/include/converse.h
+++ b/include/converse.h
@@ -421,6 +421,7 @@ extern void
 #define CMI_MEMORY_IS_OS          (1<<5)
 #define CMI_MEMORY_IS_CHARMDEBUG  (1<<6)
 int CmiMemoryIs(int flag); /* return state of this flag */
+void CpdSetInitializeMemory(int v); /* no-op outside charmdebug; needed by record-replay */
 
 // state getters
 int CmiMyPe();

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -515,6 +515,15 @@ void CmiPushPE(int destRank, int messageSize, void *msg) {
   Cmi_queues[rank]->push(msg);
 }
 
+/* Classic Converse scheduler-queue enqueue API, used by Charm++'s
+ * record-replay engine (ck.C) to re-inject messages it delayed. Reconverse's
+ * per-PE queues have no front insertion, so both variants map to a FIFO push
+ * onto the caller's own queue. For the replay engine this is correct, merely
+ * less prompt: CsdEnqueueLifo is a "process this next" hint, and every
+ * delivery re-checks the engine's expected-next predicate. */
+void CsdEnqueue(void *msg) { CmiPushPE(CmiMyRank(), msg); }
+void CsdEnqueueLifo(void *msg) { CmiPushPE(CmiMyRank(), msg); }
+
 void CmiPushPE(int destRank, void *msg) {
   CmiMessageHeader *header = static_cast<CmiMessageHeader *>(msg);
   int messageSize = header->messageSize;

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -10,6 +10,7 @@
 #include <cstdarg>
 #include <pthread.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include <stdlib.h>
 #include <thread>
 #include <vector>
@@ -523,6 +524,9 @@ void CmiPushPE(int destRank, int messageSize, void *msg) {
  * delivery re-checks the engine's expected-next predicate. */
 void CsdEnqueue(void *msg) { CmiPushPE(CmiMyRank(), msg); }
 void CsdEnqueueLifo(void *msg) { CmiPushPE(CmiMyRank(), msg); }
+
+/* Classic Converse filesystem utility, used by Charm++'s checkpoint code. */
+extern "C" void CmiMkdir(const char *dirName) { mkdir(dirName, 0777); }
 
 void CmiPushPE(int destRank, void *msg) {
   CmiMessageHeader *header = static_cast<CmiMessageHeader *>(msg);

--- a/src/convcore.cpp
+++ b/src/convcore.cpp
@@ -50,6 +50,11 @@ int quietMode;
 int quietModeRequested;
 int userDrivenMode;
 int _replaySystem = 0;
+// No-op, as in classic Converse's default allocator (memory.C): only the
+// charmdebug allocator implements it. Charm's record-replay (+record/+replay,
+// ck.C CkMessageWatcherInit) calls it unconditionally when CMK_REPLAYSYSTEM
+// is enabled, so the symbol must exist for replay-capable builds.
+void CpdSetInitializeMemory(int v) { }
 static int CmiMemoryIs_flag=0;
 CsvDeclare(CmiIpcManager*, coreIpcManager_);
 int Cmi_usched;


### PR DESCRIPTION
Two small additions that let Charm++'s record-replay engine (`+record`/`+replay`, `CMK_REPLAYSYSTEM`) run on reconverse-based builds:

- `CpdSetInitializeMemory(int)`: no-op, as in classic Converse's default allocator (only the charmdebug allocator implements it). The replay engine calls it unconditionally.
- `CsdEnqueue`/`CsdEnqueueLifo`: classic scheduler-enqueue API used by the replay engine to re-inject messages it delayed. Both map to a FIFO push onto the caller's own queue — reconverse queues have no front insertion, and for the replay engine LIFO is only a promptness hint (every delivery re-checks the expected-next predicate).

With these (plus the record-replay repairs on charm's `reconverse-specific-build`), a `--enable-tracing --enable-replay` build of charm-on-reconverse records and deterministically replays runs of the anytime-migration stress test: 2000 steps / 10491 migrations replayed twice to identical completion, single- and multi-process (2×2 via lcrun). Known limitation for a follow-up: reconverse's exit path does not run the watcher destructors, so log tails are only durable with per-record flushing (`+recplay-logsize 129`); recording idiom documented in charm-notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)